### PR TITLE
Update _hash_for_each so it bumps query_entries.size everytime it is

### DIFF
--- a/src/ds3.c
+++ b/src/ds3.c
@@ -300,6 +300,7 @@ static void _hash_for_each(gpointer _key, gpointer _value, gpointer _user_data) 
     query_entries* entries = (query_entries*) _user_data;
 
     entries->entries[entries->size] = g_strconcat(key, "=", value, NULL);
+    entries->size++;
 }
 
 static char* _net_gen_query_params(GHashTable* query_params) {


### PR DESCRIPTION
called to avoid it overwriting the previous query param that was set.
This fixes a bug where only, at most, one query param could be sent in a
request.
