### PR TITLE
Fix a bug with parsing the list objects' CommonPrefixes that would resul...

### DIFF
--- a/src/ds3.c
+++ b/src/ds3.c
@@ -865,7 +865,7 @@ static ds3_object _parse_object(xmlDocPtr doc, xmlNodePtr contents_node) {
 
 static ds3_str* _parse_common_prefixes(xmlDocPtr doc, xmlNodePtr contents_node) {
     xmlNodePtr child_node;
-    ds3_str* prefix = 0;
+    ds3_str* prefix = NULL;
     
     for(child_node = contents_node->xmlChildrenNode; child_node != NULL; child_node = child_node->next) {
         if(element_equal(child_node, "Prefix") == true) {


### PR DESCRIPTION
...t in the

response only containing the last common prefix instead of all of them.
It was assuming there would only be a single CommonPrefixes element
with multiple Prefix elements inside it.  It now matches the S3 spec
which is multiple CommonPrefixes elements each only containing a
single Prefix element.
