### PR TITLE
Fix a bug where we were using g_free to free strings allocated

### DIFF
--- a/src/ds3.c
+++ b/src/ds3.c
@@ -238,8 +238,14 @@ static char* _net_get_verb(http_verb verb) {
     return NULL;
 }
 
+// curl_easy_escape'd strings must be freed using curl_free.  Copy
+// the escaped string, using glib, since users of this function will
+// eventually wind up freeing it with g_free.
 static char* _escape_url(const char* url) {
-    return curl_easy_escape(NULL, url, 0);
+    char* curl_escaped_url = curl_easy_escape(NULL, url, 0);
+    char* escaped_url = g_strdup(curl_escaped_url);
+    curl_free(curl_escaped_url);
+    return escaped_url;
 }
 
 // Like _escape_url but don't encode "/".


### PR DESCRIPTION
with libcurl's curl_easy_escape.  Those strings must be freed with curl_free.
This fixes crashes on Windows and possibly other platforms.

Since this SDK uses g_free to free nearly all strings,
_escape_url has been updated to copy the string using glib so it can
curl_free the appropriate thing itself.  This prevents users from having
to keep track of what things need to be freed with curl_free vs g_free.
