### PR TITLE
Fix compiler errors and warnings:

### DIFF
--- a/src/ds3.c
+++ b/src/ds3.c
@@ -1259,7 +1259,7 @@ static ds3_write_optimization _match_write_optimization(const xmlChar* text) {
     }
 }
 
-static ds3_write_optimization _match_chunk_order(const xmlChar* text) {
+static ds3_chunk_ordering _match_chunk_order(const xmlChar* text) {
     if (xmlStrcmp(text, (const xmlChar*) "IN_ORDER") == 0) {
         return IN_ORDER;
     }

--- a/src/ds3.h
+++ b/src/ds3.h
@@ -243,7 +243,7 @@ LIBRARY_API size_t ds3_write_to_file(void* buffer, size_t size, size_t nmemb, vo
 LIBRARY_API size_t ds3_read_from_file(void* buffer, size_t size, size_t nmemb, void* user_data);
 
 LIBRARY_API ds3_bulk_object_list* ds3_convert_file_list(const char** file_list, uint64_t num_files);
-LIBRARY_API ds3_bulk_object_list* ds3_convert_object_list(const ds3_object* objects, size_t num_objects);
+LIBRARY_API ds3_bulk_object_list* ds3_convert_object_list(const ds3_object* objects, uint64_t num_objects);
 LIBRARY_API ds3_bulk_object_list* ds3_init_bulk_object_list(uint64_t num_files);
 LIBRARY_API void ds3_free_bulk_object_list(ds3_bulk_object_list* object_list);
 


### PR DESCRIPTION
ds3.h:
    Update ds3_convert_object_list's declaration to match
    it's definition (i.e. have num_objects be a uint64_t instead of
    a size_t)

ds3.c:
    Have _match_chunk_order return a ds3_chunk_ordering enum instead
    of a ds3_write_optimization.
