### PR TITLE
Fix ds3_init_get_available_chunks bugs:

### DIFF
--- a/src/ds3.c
+++ b/src/ds3.c
@@ -1618,13 +1618,14 @@ ds3_error* ds3_get_available_chunks(const ds3_client* client, const ds3_request*
     }
 
     _parse_master_object_list(doc, &bulk_response);
-
+    ds3_response->object_list = bulk_response;
 
     xmlFreeDoc(doc);
     g_byte_array_free(xml_blob, TRUE);
     if (response_headers != NULL) {
         g_hash_table_destroy(response_headers);
     }
+    *response = ds3_response;
     return NULL;
 }
 


### PR DESCRIPTION
o Setup a GET request instead of a PUT

o Don't free "path_str" (the "/_rest_/job_chunk/" string).  The
  allocated request structure owns that ds3_str object and will free
  it when the request itself is freed.

Fix ds3_get_available_chunks bugs so the caller can see the response.
