### PR TITLE
Namespacing the ds3_logger enum and fixing EMD-1793 (Now CSDK-1)

### DIFF
--- a/src/ds3.h
+++ b/src/ds3.h
@@ -86,7 +86,7 @@ LIBRARY_API ds3_str* ds3_str_dup(const ds3_str* string);
 LIBRARY_API void ds3_str_free(ds3_str* string);
 
 typedef enum {
-  ERROR, WARN, INFO, DEBUG, TRACE
+  DS3_ERROR, DS3_WARN, DS3_INFO, DS3_DEBUG, DS3_TRACE
 }ds3_log_lvl;
 
 typedef struct {

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -31,7 +31,7 @@ ds3_client* get_client() {
         BOOST_FAIL("Failed to setup client.");
     }
 
-    ds3_client_register_logging(client, INFO, test_log, NULL);
+    ds3_client_register_logging(client, DS3_INFO, test_log, NULL);
 
     return client;
 }


### PR DESCRIPTION
Updated the strndup method to use a glib version to avoid compile errors on windows.  Also updated the strtoul method to g_ascii_stroull method for windows so that the integer value returned is actually a 64bit unsigned int.  See EMD-1793 for more details.  Also changed all the ds3 logging enums to have a DS3_ prepended in front of them to namespace them to DS3.
