### PR TITLE
Metadata Support

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,7 +1,7 @@
 lib_LTLIBRARIES = libds3.la
-include_HEADERS = ds3.h ds3.hpp
+include_HEADERS = ds3.h ds3_string_multimap.h
 
-libds3_la_SOURCES = ds3.c
+libds3_la_SOURCES = ds3.c ds3_string_multimap.c
 libds3_la_CFLAGS = $(LIBXML2_CFLAGS) $(GLIB2_CFLAGS) $(LIBCURL_CFLAGS) -Wall
 libds3_la_LIBADD = $(LIBXML2_LIBS) $(GLIB2_LIBS) $(LIBCURL_LIBS)
 libds3_la_LDFLAGS = -version-info 0:0:0

--- a/src/ds3.c
+++ b/src/ds3.c
@@ -1717,8 +1717,21 @@ ds3_error* ds3_get_object(const ds3_client* client, const ds3_request* request, 
     return _internal_request_dispatcher(client, request, user_data, callback, NULL, NULL);
 }
 
-ds3_error* ds3_get_object_with_metadata(const ds3_client* client, const ds3_request* request, void* user_data, size_t (* callback)(void*, size_t, size_t, void*), ds3_metadata** metadata) {
-    return _internal_request_dispatcher(client, request, NULL, NULL, NULL, NULL);
+ds3_error* ds3_get_object_with_metadata(const ds3_client* client, const ds3_request* request, void* user_data, size_t (* callback)(void*, size_t, size_t, void*), ds3_metadata** _metadata) {
+  ds3_error* error;
+    GHashTable* return_headers;
+    ds3_metadata* metadata;
+
+    error = _net_process_request(client, request, user_data, callback, NULL, NULL, &return_headers);
+
+    if (error == NULL) {
+        fprintf(stderr, "Head object completed successfully\n");
+        metadata = _init_metadata(return_headers);
+        *_metadata = metadata;
+        g_hash_table_destroy(return_headers);
+    }
+
+    return error;
 }
 
 ds3_error* ds3_put_object(const ds3_client* client, const ds3_request* request, void* user_data, size_t (*callback)(void*, size_t, size_t, void*)) {

--- a/src/ds3.c
+++ b/src/ds3.c
@@ -659,14 +659,14 @@ static gint _gstring_sort(gconstpointer a, gconstpointer b) {
     char* val1 = (char*)a;
     char* val2 = (char*)b;
 
-    return g_strcmp0(val1, val2);
+    return g_strcmp0(val2, val1);
 }
 
 static char* _canonicalize_amz_headers(GHashTable* headers) {
     GList* keys = g_hash_table_get_keys(headers);
     GList* key = keys;
     GString* canonicalized_headers = g_string_new("");
-    GPtrArray *signing_strings = g_ptr_array_new_with_free_func(_ds3_internal_str_free);
+    GPtrArray *signing_strings = g_ptr_array_new_with_free_func(g_free);  // stores char*
     GString* header_signing_value;
     char* signing_value;
     int i;

--- a/src/ds3.c
+++ b/src/ds3.c
@@ -2956,8 +2956,8 @@ void ds3_free_available_chunks_response(ds3_get_available_chunks_response* respo
 }
 
 void ds3_free_metadata_entry(ds3_metadata_entry* entry) {
-  int i;
-  ds3_str* value;
+    int i;
+    ds3_str* value;
     if (entry->name != NULL) {
         ds3_str_free(entry->name);
     }
@@ -2971,4 +2971,23 @@ void ds3_free_metadata_entry(ds3_metadata_entry* entry) {
         g_free(entry->values);
     }
     g_free(entry);
+}
+
+void ds3_free_metadata_keys(ds3_metadata_keys_result* metadata_keys) {
+    uint64_t i;
+    ds3_str* value;
+    if (metadata_keys == NULL) {
+        return;
+    }
+
+    if (metadata_keys->keys != NULL) {
+        for (i = 0; i < metadata_keys->num_keys; i++) {
+            value = metadata_keys->keys[i];
+            if (value != NULL) {
+                ds3_str_free(value);
+            }
+        }
+        g_free(metadata_keys->keys);
+    }
+    g_free(metadata_keys);
 }

--- a/src/ds3.c
+++ b/src/ds3.c
@@ -656,10 +656,10 @@ static int ds3_curl_logger(CURL *handle, curl_infotype type, char* data, size_t 
 }
 
 static gint _gstring_sort(gconstpointer a, gconstpointer b) {
-    char* val1 = (char*)a;
-    char* val2 = (char*)b;
+    char** val1 = (char**)a;
+    char** val2 = (char**)b;
 
-    return g_strcmp0(val2, val1);
+    return g_strcmp0(*val1, *val2);
 }
 
 static char* _canonicalize_amz_headers(GHashTable* headers) {

--- a/src/ds3.c
+++ b/src/ds3.c
@@ -50,6 +50,10 @@ struct _ds3_request{
     ds3_chunk_ordering chunk_ordering;
 };
 
+struct _ds3_metadata {
+  GHashTable* metadata;
+};
+
 typedef struct {
     char* buff;
     size_t size;
@@ -118,6 +122,22 @@ void ds3_client_register_logging(ds3_client* client, ds3_log_lvl log_lvl, void (
     log->log_lvl = log_lvl;
 
     client->log = log;
+}
+
+static ds3_metadata* _init_metadata() {
+
+}
+
+ds3_metadata_entry* ds3_metadata_get_entry(const ds3_metadata* metadata, const char* name) {
+
+}
+
+uint64_t ds3_metadata_size(const ds3_metadata* metadata) {
+
+}
+
+ds3_metadata_keys_result* ds3_metadata_keys(const ds3_metadata* metadata) {
+
 }
 
 ds3_str* ds3_str_init(const char* string) {
@@ -838,6 +858,10 @@ ds3_request* ds3_init_get_bucket(const char* bucket_name) {
     return (ds3_request*) _common_request_init(HTTP_GET, _build_path("/", bucket_name, NULL));
 }
 
+ds3_request* ds3_init_head_object(const char* bucket_name, const char* object_name) {
+    return (ds3_request*) _common_request_init(HTTP_HEAD, _build_path("/", bucket_name, object_name));
+}
+
 ds3_request* ds3_init_get_object_for_job(const char* bucket_name, const char* object_name, uint64_t offset, const char* job_id) {
     char buff[21];
     struct _ds3_request* request = _common_request_init(HTTP_GET, _build_path("/", bucket_name, object_name));
@@ -1317,8 +1341,16 @@ ds3_error* ds3_get_bucket(const ds3_client* client, const ds3_request* request, 
     return NULL;
 }
 
+ds3_error* ds3_head_object(const ds3_client* client, const ds3_request* request, ds3_metadata** metadata) {
+    return _internal_request_dispatcher(client, request, NULL, NULL, NULL, NULL);
+}
+
 ds3_error* ds3_get_object(const ds3_client* client, const ds3_request* request, void* user_data, size_t(*callback)(void*,size_t, size_t, void*)) {
     return _internal_request_dispatcher(client, request, user_data, callback, NULL, NULL);
+}
+
+ds3_error* ds3_get_object_with_metadata(const ds3_client* client, const ds3_request* request, void* user_data, size_t (* callback)(void*, size_t, size_t, void*), ds3_metadata** metadata) {
+    return _internal_request_dispatcher(client, request, NULL, NULL, NULL, NULL);
 }
 
 ds3_error* ds3_put_object(const ds3_client* client, const ds3_request* request, void* user_data, size_t (*callback)(void*, size_t, size_t, void*)) {
@@ -2213,6 +2245,10 @@ void ds3_free_request(ds3_request* _request) {
         ds3_str_free(request->md5);
     }
     g_free(request);
+}
+
+void ds3_free_metadata(ds3_metadata* metadata) {
+
 }
 
 void ds3_free_error(ds3_error* error) {

--- a/src/ds3.c
+++ b/src/ds3.c
@@ -124,11 +124,34 @@ void ds3_client_register_logging(ds3_client* client, ds3_log_lvl log_lvl, void (
     client->log = log;
 }
 
-/*
-static ds3_metadata* _init_metadata() {
+static void _ds3_free_metadata_entry(gpointer pointer) {
+    int i;
+    ds3_str* value;
+    if (pointer == NULL) {
+        return; // do nothing
+    }
 
+    ds3_metadata_entry* entry = (ds3_metadata_entry*) pointer;
+    if (entry->name != NULL) {
+        ds3_str_free(entry->name);
+    }
+    if (entry->values != NULL) {
+        for (i = 0; i < entry->num_values; i++) {
+            value = entry->values[i];
+            if (value != NULL) {
+                ds3_str_free(value);
+            }
+        }
+        g_free(entry->values);
+    }
+    g_free(entry);
 }
 
+static ds3_metadata* _init_metadata(GHashTable* headers) {
+    struct _ds3_metadata* metadata = g_new0(struct _ds3_metadata, 1);
+    metadata->metadata = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, _ds3_free_metadata_entry);
+    return (ds3_metadata*) metadata;
+}
 ds3_metadata_entry* ds3_metadata_get_entry(const ds3_metadata* metadata, const char* name) {
 
 }
@@ -140,7 +163,7 @@ uint64_t ds3_metadata_size(const ds3_metadata* metadata) {
 ds3_metadata_keys_result* ds3_metadata_keys(const ds3_metadata* metadata) {
 
 }
-*/
+
 ds3_str* ds3_str_init(const char* string) {
     size_t size = strlen(string);
     return ds3_str_init_with_size(string, size);

--- a/src/ds3.c
+++ b/src/ds3.c
@@ -1,6 +1,6 @@
 /*
 * ******************************************************************************
-*   Copyright 2014 Spectra Logic Corporation. All Rights Reserved.
+*   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
 *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
 *   this file except in compliance with the License. A copy of the License is located at
 *
@@ -51,7 +51,7 @@ struct _ds3_request{
 };
 
 struct _ds3_metadata {
-  GHashTable* metadata;
+    GHashTable* metadata;
 };
 
 typedef struct {

--- a/src/ds3.c
+++ b/src/ds3.c
@@ -152,6 +152,7 @@ static ds3_metadata* _init_metadata(GHashTable* headers) {
     metadata->metadata = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, _ds3_free_metadata_entry);
     return (ds3_metadata*) metadata;
 }
+
 ds3_metadata_entry* ds3_metadata_get_entry(const ds3_metadata* metadata, const char* name) {
 
 }
@@ -822,6 +823,7 @@ static void _set_map_value(GHashTable* map, const char* key, const char* value) 
     gpointer escaped_key = (gpointer) _escape_url(key);
     gpointer escaped_value = (gpointer) _escape_url(value);
 
+    //TODO update this to handle multiple values being set for a header field
     g_hash_table_insert(map, escaped_key, escaped_value);
 }
 
@@ -841,6 +843,15 @@ void ds3_client_proxy(ds3_client* client, const char* proxy) {
 
 void ds3_request_set_prefix(ds3_request* _request, const char* prefix) {
     _set_query_param(_request, "prefix", prefix);
+}
+
+void ds3_request_set_metadata(ds3_request* _request, const char* name, const char* value) {
+
+    char* prefixed_name = g_strconcat("x-amz-meta-", name, NULL);
+
+    _set_header(_request, prefixed_name, value);
+
+    g_free(prefixed_name);
 }
 
 void ds3_request_set_custom_header(ds3_request* _request, const char* header_name, const char* header_value) {

--- a/src/ds3.h
+++ b/src/ds3.h
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- *   Copyright 2014 Spectra Logic Corporation. All Rights Reserved.
+ *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
  *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
  *   this file except in compliance with the License. A copy of the License is located at
  *

--- a/src/ds3.h
+++ b/src/ds3.h
@@ -220,6 +220,23 @@ typedef struct {
     ds3_error_response* error;
 }ds3_error;
 
+typedef struct {
+    char*      name;
+    ds3_str**  values;
+    uint64_t   num_values
+}ds3_metadata_entry;
+
+typedef struct {
+    ds3_str**  keys;
+    uint64_t   num_keys;
+}ds3_metadata_keys;
+
+typedef struct _ds3_metadata ds3_metadata;
+
+LIBRARY_API ds3_metadata_entry* ds3_metadata_get_entry(const ds3_metadata* metadata, const char* name);
+LIBRARY_API uint64_t ds3_metadata_size(const ds3_metadata* metadata);
+LIBRARY_API ds3_metadata_keys* ds3_metadata_keys(const ds3_metadata* metadata);
+
 LIBRARY_API ds3_creds*  ds3_create_creds(const char* access_id, const char* secret_key);
 LIBRARY_API ds3_client* ds3_create_client(const char* endpoint, ds3_creds* creds);
 LIBRARY_API ds3_error*  ds3_create_client_from_env(ds3_client** client);
@@ -227,6 +244,7 @@ LIBRARY_API void        ds3_client_register_logging(ds3_client* client, ds3_log_
 
 LIBRARY_API ds3_request* ds3_init_get_service(void);
 LIBRARY_API ds3_request* ds3_init_get_bucket(const char* bucket_name);
+LIBRARY_API ds3_request* ds3_init_head_object(const char* bucket_name, const char* object_name);
 LIBRARY_API ds3_request* ds3_init_get_object_for_job(const char* bucket_name, const char* object_name, uint64_t offset, const char* job_id);
 LIBRARY_API ds3_request* ds3_init_put_bucket(const char* bucket_name);
 LIBRARY_API ds3_request* ds3_init_put_object_for_job(const char* bucket_name, const char* object_name, uint64_t offset, uint64_t length, const char* job_id);
@@ -251,7 +269,7 @@ LIBRARY_API void ds3_request_set_delimiter(ds3_request* request, const char* del
 LIBRARY_API void ds3_request_set_marker(ds3_request* request, const char* marker);
 LIBRARY_API void ds3_request_set_max_keys(ds3_request* request, uint32_t max_keys);
 LIBRARY_API void ds3_request_set_md5(ds3_request* request, const char* md5);
-
+LIBRARY_API void ds3_request_set_metadata(ds3_request* request, const char* name, const char* value);
 
 LIBRARY_API ds3_error* ds3_get_service(const ds3_client* client, const ds3_request* request, ds3_get_service_response** response);
 LIBRARY_API ds3_error* ds3_get_bucket(const ds3_client* client, const ds3_request* request, ds3_get_bucket_response** response);
@@ -261,7 +279,9 @@ LIBRARY_API ds3_error* ds3_get_available_chunks(const ds3_client* client, const 
 
 LIBRARY_API ds3_error* ds3_put_bucket(const ds3_client* client, const ds3_request* request);
 LIBRARY_API ds3_error* ds3_delete_bucket(const ds3_client* client, const ds3_request* request);
+LIBRARY_API ds3_error* ds3_head_object(const ds3_client* client, const ds3_request* request, ds3_metadata** metadata);
 LIBRARY_API ds3_error* ds3_get_object(const ds3_client* client, const ds3_request* request, void* user_data, size_t (* callback)(void*, size_t, size_t, void*));
+LIBRARY_API ds3_error* ds3_get_object_with_metadata(const ds3_client* client, const ds3_request* request, void* user_data, size_t (* callback)(void*, size_t, size_t, void*), ds3_metadata** metadata);
 LIBRARY_API ds3_error* ds3_put_object(const ds3_client* client, const ds3_request* request, void* user_data, size_t (* callback)(void*, size_t, size_t, void*));
 LIBRARY_API ds3_error* ds3_delete_object(const ds3_client* client, const ds3_request* request);
 LIBRARY_API ds3_error* ds3_get_job(const ds3_client* client, const ds3_request* request, ds3_bulk_response** response);
@@ -280,9 +300,11 @@ LIBRARY_API void ds3_free_owner(ds3_owner* owner);
 LIBRARY_API void ds3_free_creds(ds3_creds* client);
 LIBRARY_API void ds3_free_client(ds3_client* client);
 LIBRARY_API void ds3_free_request(ds3_request* request);
+LIBRARY_API void ds3_free_metadata(ds3_metadata* metadata);
 LIBRARY_API void ds3_cleanup(void);
 
 LIBRARY_API void ds3_print_request(const ds3_request* request);
+
 // provided helpers
 LIBRARY_API size_t ds3_write_to_file(void* buffer, size_t size, size_t nmemb, void* user_data);
 LIBRARY_API size_t ds3_read_from_file(void* buffer, size_t size, size_t nmemb, void* user_data);

--- a/src/ds3.h
+++ b/src/ds3.h
@@ -333,6 +333,7 @@ LIBRARY_API void ds3_free_client(ds3_client* client);
 LIBRARY_API void ds3_free_request(ds3_request* request);
 LIBRARY_API void ds3_free_metadata(ds3_metadata* metadata);
 LIBRARY_API void ds3_free_metadata_entry(ds3_metadata_entry* metadata_entry);
+LIBRARY_API void ds3_free_metadata_keys(ds3_metadata_keys_result* metadata_keys);
 LIBRARY_API void ds3_free_objects_response(ds3_get_objects_response* response);
 LIBRARY_API void ds3_cleanup(void);
 

--- a/src/ds3.h
+++ b/src/ds3.h
@@ -223,19 +223,19 @@ typedef struct {
 typedef struct {
     char*      name;
     ds3_str**  values;
-    uint64_t   num_values
+    uint64_t   num_values;
 }ds3_metadata_entry;
 
 typedef struct {
     ds3_str**  keys;
     uint64_t   num_keys;
-}ds3_metadata_keys;
+}ds3_metadata_keys_result;
 
 typedef struct _ds3_metadata ds3_metadata;
 
 LIBRARY_API ds3_metadata_entry* ds3_metadata_get_entry(const ds3_metadata* metadata, const char* name);
 LIBRARY_API uint64_t ds3_metadata_size(const ds3_metadata* metadata);
-LIBRARY_API ds3_metadata_keys* ds3_metadata_keys(const ds3_metadata* metadata);
+LIBRARY_API ds3_metadata_keys_result* ds3_metadata_keys(const ds3_metadata* metadata);
 
 LIBRARY_API ds3_creds*  ds3_create_creds(const char* access_id, const char* secret_key);
 LIBRARY_API ds3_client* ds3_create_client(const char* endpoint, ds3_creds* creds);

--- a/src/ds3.h
+++ b/src/ds3.h
@@ -221,7 +221,7 @@ typedef struct {
 }ds3_error;
 
 typedef struct {
-    char*      name;
+    ds3_str*      name;
     ds3_str**  values;
     uint64_t   num_values;
 }ds3_metadata_entry;

--- a/src/ds3.h
+++ b/src/ds3.h
@@ -221,9 +221,9 @@ typedef struct {
 }ds3_error;
 
 typedef struct {
-    ds3_str*      name;
-    ds3_str**  values;
-    uint64_t   num_values;
+    ds3_str*    name;
+    ds3_str**   values;
+    uint64_t    num_values;
 }ds3_metadata_entry;
 
 typedef struct {
@@ -234,7 +234,7 @@ typedef struct {
 typedef struct _ds3_metadata ds3_metadata;
 
 LIBRARY_API ds3_metadata_entry* ds3_metadata_get_entry(const ds3_metadata* metadata, const char* name);
-LIBRARY_API uint64_t ds3_metadata_size(const ds3_metadata* metadata);
+LIBRARY_API unsigned int ds3_metadata_size(const ds3_metadata* metadata);
 LIBRARY_API ds3_metadata_keys_result* ds3_metadata_keys(const ds3_metadata* metadata);
 
 LIBRARY_API ds3_creds*  ds3_create_creds(const char* access_id, const char* secret_key);
@@ -301,6 +301,7 @@ LIBRARY_API void ds3_free_creds(ds3_creds* client);
 LIBRARY_API void ds3_free_client(ds3_client* client);
 LIBRARY_API void ds3_free_request(ds3_request* request);
 LIBRARY_API void ds3_free_metadata(ds3_metadata* metadata);
+LIBRARY_API void ds3_free_metadata_entry(ds3_metadata_entry* metadata_entry);
 LIBRARY_API void ds3_cleanup(void);
 
 LIBRARY_API void ds3_print_request(const ds3_request* request);

--- a/src/ds3_string_multimap.c
+++ b/src/ds3_string_multimap.c
@@ -1,0 +1,47 @@
+#include <glib.h>
+#include "ds3_string_multimap.h"
+
+struct _ds3_string_multimap {
+    GHashTable* hash;
+};
+
+
+static void _free_pointer_array(gpointer pointer) {
+    GPtrArray* array = (GPtrArray*) pointer;
+
+    g_ptr_array_free(array, TRUE);
+}
+
+ds3_string_multimap* ds3_string_multimap_init(void) {
+    struct _ds3_string_multimap* multimap = g_new0(struct _ds3_string_multimap, 1);
+    multimap->hash = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, _free_pointer_array);
+
+    return (ds3_string_multimap*) multimap;
+}
+
+void ds3_string_multimap_insert(ds3_string_multimap* _hashtable, char* key, char* value) {
+    struct _ds3_string_multimap* map = (struct _ds3_string_multimap*) _hashtable;
+    GPtrArray* entries = (GPtrArray*) g_hash_table_lookup(map->hash, key);
+    if (entries == NULL) {
+        entries = g_ptr_array_new_with_free_func(g_free);
+        g_hash_table_insert(map->hash, key, entries);
+    }
+    g_ptr_array_add(entries, value);
+}
+
+GPtrArray* ds3_string_multimap_lookup(ds3_string_multimap* hashtable, char* key) {
+    struct _ds3_string_multimap* map = (struct _ds3_string_multimap*) hashtable;
+    return g_hash_table_lookup(map->hash, key);
+}
+
+void ds3_string_multimap_free(ds3_string_multimap* _map) {
+    struct _ds3_string_multimap* map;
+    if (_map == NULL) return;
+    map = (struct _ds3_string_multimap*) _map;
+
+    if (map->hash != NULL) {
+        g_hash_table_destroy(map->hash);
+    }
+
+    g_free(map);
+}

--- a/src/ds3_string_multimap.c
+++ b/src/ds3_string_multimap.c
@@ -1,3 +1,18 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
 #include <glib.h>
 #include "ds3_string_multimap.h"
 

--- a/src/ds3_string_multimap.h
+++ b/src/ds3_string_multimap.h
@@ -1,0 +1,48 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+#ifndef __DS3_STRING_MULTIMAP__
+#define __DS3_STRING_MULTIMAP__
+
+#include <glib.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct _ds3_string_multimap ds3_string_multimap;
+
+//opertions for manipulating a hash map as a string multi map
+ds3_string_multimap* ds3_string_multimap_init(void);
+void ds3_string_multimap_insert(ds3_string_multimap* hashtable, char* key, char* value);
+GPtrArray* ds3_string_multimap_lookup(ds3_string_multimap* hashtable, char* key);
+void ds3_string_multimap_free(ds3_string_multimap* map);
+/*
+// TODO implement this as a future refactor
+// operations for multimaps
+typedef struct _ds3_multi_map ds3_multi_map;
+
+typedef unsigned int (*ds3_hash_func)(void* pointer);
+typedef int (*ds3_equal_func)(void* pointer);
+
+LIBRARY_API ds3_multi_map* ds3_multi_map_init(ds3_hash_func hash, ds3_equal_func equal);
+LIBRARY_API void ds3_multi_map_put(void* key, void* data);
+LIBRARY_API void* ds3_multi_map_get(void* key);
+LIBRARY_API void ds3_multi_map_free(ds3_multi_map* map);
+*/
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/test/Makefile
+++ b/test/Makefile
@@ -37,7 +37,7 @@ run: test
 deps:
 	./build_local.sh
 
-test: test.o checksum.o service_tests.o bucket_tests.o job_tests.o bulk_get.o get_physical_placement.o negative_tests.o 
+test: test.o checksum.o service_tests.o bucket_tests.o job_tests.o bulk_get.o get_physical_placement.o negative_tests.o
 	$(CPP) *.o $(CFLAGS) $(LIBS) -o test
 
 test.o: ../install/lib/pkgconfig/libds3.pc

--- a/test/Makefile
+++ b/test/Makefile
@@ -37,11 +37,14 @@ run: test
 deps:
 	./build_local.sh
 
-test: test.o checksum.o service_tests.o bucket_tests.o job_tests.o bulk_get.o get_physical_placement.o negative_tests.o
+test: test.o checksum.o service_tests.o bucket_tests.o job_tests.o bulk_get.o get_physical_placement.o negative_tests.o metadata_tests.o
 	$(CPP) *.o $(CFLAGS) $(LIBS) -o test
 
 test.o: ../install/lib/pkgconfig/libds3.pc
 	$(CPP) -c test.cpp $(CFLAGS)
+
+metadata_tests.o:
+	$(CPP) -c metadata_tests.cpp $(CFLAGS)
 
 service_tests.o:
 	$(CPP) -c service_tests.cpp $(CFLAGS)

--- a/test/Makefile
+++ b/test/Makefile
@@ -64,9 +64,12 @@ get_physical_placement.o:
 negative_tests.o:
 	$(CPP) -c negative_tests.cpp $(CFLAGS)
 
+multimap_tests.o:
+	$(CPP) -c mulitmap_tests.cpp $(CFLAGS)
+
 checksum.o:
 	$(CPP) -c checksum.cpp $(CFLAGS)
-	
+
 ../install/lib/pkgconfig/libds3.pc:
 	$(error SDK not built. Please run make deps)
 

--- a/test/bucket_tests.cpp
+++ b/test/bucket_tests.cpp
@@ -183,7 +183,7 @@ BOOST_AUTO_TEST_CASE(md5_checksum) {
           FILE* file = fopen(bulk_object.name->value, "r");
 
           request = ds3_init_put_object_for_job(bucket_name, bulk_object.name->value, bulk_object.offset,  bulk_object.length, response->job_id->value);
-          ds3_request_set_md5(request,"0bfc07b888d354413cfb662651a0ad8d");
+          ds3_request_set_md5(request,"rCu751L6xhB5zyL+soa3fg==");
 
           if (bulk_object.offset > 0) {
               fseek(file, bulk_object.offset, SEEK_SET);

--- a/test/bucket_tests.cpp
+++ b/test/bucket_tests.cpp
@@ -87,29 +87,29 @@ BOOST_AUTO_TEST_CASE( delimiter ) {
 }
 
 BOOST_AUTO_TEST_CASE(marker) {
-	  ds3_request* request;
-	  ds3_error* error;
-	  ds3_get_bucket_response* response;
-	  ds3_client* client = get_client();
-	  const char* bucket_name = "bucket_test_marker";
-	  uint64_t num_objs;
+    ds3_request* request;
+    ds3_error* error;
+    ds3_get_bucket_response* response;
+    ds3_client* client = get_client();
+    const char* bucket_name = "bucket_test_marker";
+    uint64_t num_objs;
 
-	  populate_with_objects(client,bucket_name);
+    populate_with_objects(client,bucket_name);
 
-	  request = ds3_init_get_bucket(bucket_name);
-	  ds3_request_set_marker(request,"resources/sherlock_holmes.txt");
-	  error = ds3_get_bucket(client,request,&response);
-	  ds3_free_request(request);
+    request = ds3_init_get_bucket(bucket_name);
+    ds3_request_set_marker(request,"resources/sherlock_holmes.txt");
+    error = ds3_get_bucket(client,request,&response);
+    ds3_free_request(request);
 
-	  handle_error(error);
-	  num_objs = response->num_objects;
+    handle_error(error);
+    num_objs = response->num_objects;
 
-	  BOOST_CHECK_EQUAL(num_objs, 3);
-	  BOOST_CHECK(contains_object(response->objects, num_objs, "resources/tale_of_two_cities.txt"));
-	  BOOST_CHECK(contains_object(response->objects, num_objs, "resources/ulysses.txt"));
-	  BOOST_CHECK(contains_object(response->objects, num_objs, "resources/ulysses_large.txt"));
+    BOOST_CHECK_EQUAL(num_objs, 3);
+    BOOST_CHECK(contains_object(response->objects, num_objs, "resources/tale_of_two_cities.txt"));
+    BOOST_CHECK(contains_object(response->objects, num_objs, "resources/ulysses.txt"));
+    BOOST_CHECK(contains_object(response->objects, num_objs, "resources/ulysses_large.txt"));
 
-	  ds3_free_bucket_response(response);
+    ds3_free_bucket_response(response);
 
     clear_bucket(client, bucket_name);
     free_client(client);
@@ -117,35 +117,35 @@ BOOST_AUTO_TEST_CASE(marker) {
 
 BOOST_AUTO_TEST_CASE(max_keys) {
     ds3_request* request;
-	  ds3_error* error;
-	  ds3_get_bucket_response* response;
-	  ds3_client* client = get_client();
-	  const char* bucket_name = "bucket_test_max_keys";
-	  uint64_t num_objs;
+    ds3_error* error;
+    ds3_get_bucket_response* response;
+    ds3_client* client = get_client();
+    const char* bucket_name = "bucket_test_max_keys";
+    uint64_t num_objs;
 
-	  populate_with_objects(client,bucket_name);
+    populate_with_objects(client,bucket_name);
 
-	  request = ds3_init_get_bucket(bucket_name);
-	  ds3_request_set_max_keys(request,2);
+    request = ds3_init_get_bucket(bucket_name);
+    ds3_request_set_max_keys(request,2);
 
-	  error = ds3_get_bucket(client,request,&response);
-	  ds3_free_request(request);
+    error = ds3_get_bucket(client,request,&response);
+    ds3_free_request(request);
 
-	  handle_error(error);
-	  num_objs = response->num_objects;
+    handle_error(error);
+    num_objs = response->num_objects;
 
-	  BOOST_CHECK_EQUAL(num_objs, 2);
-	  BOOST_CHECK(contains_object(response->objects, num_objs, "resources/beowulf.txt"));
-	  BOOST_CHECK(contains_object(response->objects, num_objs, "resources/sherlock_holmes.txt"));
-	  ds3_free_bucket_response(response);
+    BOOST_CHECK_EQUAL(num_objs, 2);
+    BOOST_CHECK(contains_object(response->objects, num_objs, "resources/beowulf.txt"));
+    BOOST_CHECK(contains_object(response->objects, num_objs, "resources/sherlock_holmes.txt"));
+    ds3_free_bucket_response(response);
 
     clear_bucket(client, bucket_name);
     free_client(client);
 }
 
 BOOST_AUTO_TEST_CASE(md5_checksum) {
-  	uint64_t i, n;
-	  const char* bucket_name = "bucket_test_md5";
+    uint64_t i, n;
+    const char* bucket_name = "bucket_test_md5";
     ds3_request* request = ds3_init_put_bucket(bucket_name);
     const char* books[] ={"resources/beowulf.txt"};
     ds3_client* client = get_client();

--- a/test/bucket_tests.cpp
+++ b/test/bucket_tests.cpp
@@ -76,7 +76,7 @@ BOOST_AUTO_TEST_CASE( delimiter ) {
     BOOST_CHECK(error == NULL);
     num_objs = response->num_objects;
     BOOST_CHECK_EQUAL(num_objs, 0);
-	
+
     BOOST_CHECK_EQUAL(response->num_common_prefixes, 1);
     BOOST_CHECK_EQUAL(strcmp(response->common_prefixes[0]->value, "resources/"), 0);
 
@@ -86,71 +86,68 @@ BOOST_AUTO_TEST_CASE( delimiter ) {
     free_client(client);
 }
 
-BOOST_AUTO_TEST_CASE(marker){
-	ds3_request* request;
-	ds3_error* error;
-	ds3_get_bucket_response* response;
-	ds3_client* client = get_client();
-	const char* bucket_name = "bucket_test_marker";
-	uint64_t num_objs;
-	
-	populate_with_objects(client,bucket_name);
-	
-	request = ds3_init_get_bucket(bucket_name);
-	ds3_request_set_marker(request,"resources/sherlock_holmes.txt");
-	error = ds3_get_bucket(client,request,&response);
-	ds3_free_request(request);
-	
-	handle_error(error);
-	num_objs = response->num_objects;
-	
-	BOOST_CHECK_EQUAL(num_objs, 3);
-	BOOST_CHECK(contains_object(response->objects, num_objs, "resources/tale_of_two_cities.txt"));
-	BOOST_CHECK(contains_object(response->objects, num_objs, "resources/ulysses.txt"));
-	BOOST_CHECK(contains_object(response->objects, num_objs, "resources/ulysses_large.txt"));
-	
-	ds3_free_bucket_response(response);
+BOOST_AUTO_TEST_CASE(marker) {
+	  ds3_request* request;
+	  ds3_error* error;
+	  ds3_get_bucket_response* response;
+	  ds3_client* client = get_client();
+	  const char* bucket_name = "bucket_test_marker";
+	  uint64_t num_objs;
+
+	  populate_with_objects(client,bucket_name);
+
+	  request = ds3_init_get_bucket(bucket_name);
+	  ds3_request_set_marker(request,"resources/sherlock_holmes.txt");
+	  error = ds3_get_bucket(client,request,&response);
+	  ds3_free_request(request);
+
+	  handle_error(error);
+	  num_objs = response->num_objects;
+
+	  BOOST_CHECK_EQUAL(num_objs, 3);
+	  BOOST_CHECK(contains_object(response->objects, num_objs, "resources/tale_of_two_cities.txt"));
+	  BOOST_CHECK(contains_object(response->objects, num_objs, "resources/ulysses.txt"));
+	  BOOST_CHECK(contains_object(response->objects, num_objs, "resources/ulysses_large.txt"));
+
+	  ds3_free_bucket_response(response);
 
     clear_bucket(client, bucket_name);
     free_client(client);
-	
-	
 }
 
-BOOST_AUTO_TEST_CASE(max_keys)
-{
-	ds3_request* request;
-	ds3_error* error;
-	ds3_get_bucket_response* response;
-	ds3_client* client = get_client();
-	const char* bucket_name = "bucket_test_max_keys";
-	uint64_t num_objs;
-	
-	populate_with_objects(client,bucket_name);
-	
-	request = ds3_init_get_bucket(bucket_name);
-	ds3_request_set_max_keys(request,2);
-	
-	error = ds3_get_bucket(client,request,&response);
-	ds3_free_request(request);
-	
-	handle_error(error);
-	num_objs = response->num_objects;
-	
-	BOOST_CHECK_EQUAL(num_objs, 2);
-	BOOST_CHECK(contains_object(response->objects, num_objs, "resources/beowulf.txt"));
-	BOOST_CHECK(contains_object(response->objects, num_objs, "resources/sherlock_holmes.txt"));
-	ds3_free_bucket_response(response);
+BOOST_AUTO_TEST_CASE(max_keys) {
+    ds3_request* request;
+	  ds3_error* error;
+	  ds3_get_bucket_response* response;
+	  ds3_client* client = get_client();
+	  const char* bucket_name = "bucket_test_max_keys";
+	  uint64_t num_objs;
+
+	  populate_with_objects(client,bucket_name);
+
+	  request = ds3_init_get_bucket(bucket_name);
+	  ds3_request_set_max_keys(request,2);
+
+	  error = ds3_get_bucket(client,request,&response);
+	  ds3_free_request(request);
+
+	  handle_error(error);
+	  num_objs = response->num_objects;
+
+	  BOOST_CHECK_EQUAL(num_objs, 2);
+	  BOOST_CHECK(contains_object(response->objects, num_objs, "resources/beowulf.txt"));
+	  BOOST_CHECK(contains_object(response->objects, num_objs, "resources/sherlock_holmes.txt"));
+	  ds3_free_bucket_response(response);
 
     clear_bucket(client, bucket_name);
     free_client(client);
-		
 }
 
-BOOST_AUTO_TEST_CASE(md5_checksum)
-{
-	uint64_t i, n;
-	const char* bucket_name = "bucket_test_md5";
+/* TODO uncomment with latest sim
+
+BOOST_AUTO_TEST_CASE(md5_checksum) {
+  	uint64_t i, n;
+	  const char* bucket_name = "bucket_test_md5";
     ds3_request* request = ds3_init_put_bucket(bucket_name);
     const char* books[] ={"resources/beowulf.txt"};
     ds3_client* client = get_client();
@@ -158,7 +155,7 @@ BOOST_AUTO_TEST_CASE(md5_checksum)
     ds3_bulk_object_list* obj_list;
     ds3_bulk_response* response;
     ds3_allocate_chunk_response* chunk_response;
-    
+
 
     ds3_free_request(request);
 
@@ -170,8 +167,6 @@ BOOST_AUTO_TEST_CASE(md5_checksum)
 
     ds3_free_request(request);
     handle_error(error);
-
- 
 
     for (n = 0; n < response->list_size; n ++) {
 
@@ -191,7 +186,7 @@ BOOST_AUTO_TEST_CASE(md5_checksum)
 
           request = ds3_init_put_object_for_job(bucket_name, bulk_object.name->value, bulk_object.offset,  bulk_object.length, response->job_id->value);
           ds3_request_set_md5(request,"0bfc07b888d354413cfb662651a0ad8d");
-         
+
           if (bulk_object.offset > 0) {
               fseek(file, bulk_object.offset, SEEK_SET);
           }
@@ -202,14 +197,11 @@ BOOST_AUTO_TEST_CASE(md5_checksum)
       }
      ds3_free_allocate_chunk_response(chunk_response);
     }
-    
+
     ds3_free_bulk_response(response);
     ds3_free_bulk_object_list(obj_list);
     clear_bucket(client, bucket_name);
     free_client(client);
 }
 
-
-
-
-
+*/

--- a/test/checksum.cpp
+++ b/test/checksum.cpp
@@ -11,7 +11,6 @@
 gchar* result_1;
 gchar* result_2;
 
-
 // Get the size of the file by its file descriptor
 unsigned long get_size_by_fd(int fd) {
     struct stat statbuf;
@@ -20,56 +19,46 @@ unsigned long get_size_by_fd(int fd) {
 }
 
 // Function which compares checksums of the files passed
-void compare_hash(char* filename_1, char* filename_2) 
-{
+void compare_hash(char* filename_1, char* filename_2) {
     int file_descript_1;
     int file_descript_2;
     unsigned long file_size_1,file_size_2;
     char* file_buffer_1;
     char* file_buffer_2;
 
-    if(!filename_1 || !filename_2) { 
-            printf("Must specify two files to be compared\n");
-            exit(-1);
+    if(!filename_1 || !filename_2) {
+        printf("Must specify two files to be compared\n");
+        exit(-1);
     }
     printf("Orignal file:\t%s\n", filename_1);
     printf("File to be checked:\t%s\n", filename_2);
 
     file_descript_1 = open(filename_1, O_RDONLY);
     if(file_descript_1 < 0) exit(-1);
-	
-	file_descript_2 = open(filename_2, O_RDONLY);
+
+    file_descript_2 = open(filename_2, O_RDONLY);
     if(file_descript_2 < 0) exit(-1);
-	
+
     file_size_1 = get_size_by_fd(file_descript_1);
-   
-	file_size_2 = get_size_by_fd(file_descript_2);
- 
-	
+
+    file_size_2 = get_size_by_fd(file_descript_2);
 
     file_buffer_1 = static_cast<char*>(mmap(0, file_size_1, PROT_READ, MAP_SHARED, file_descript_1, 0));
     result_1 = g_compute_checksum_for_string(G_CHECKSUM_MD5,file_buffer_1,file_size_1);
-	printf("%s(checksum):",filename_1);
+    printf("%s(checksum):",filename_1);
     printf("%s\n",result_1);
-    
+
     file_buffer_2 = static_cast<char*>(mmap(0, file_size_2, PROT_READ, MAP_SHARED, file_descript_2, 0));
     result_2 = g_compute_checksum_for_string(G_CHECKSUM_MD5,file_buffer_2,file_size_2);
-	printf("%s(checksum):",filename_2);
+    printf("%s(checksum):",filename_2);
     printf("%s\n",result_2);
-   
-    if(strcmp(reinterpret_cast<char*>(result_1),reinterpret_cast<char*>(result_2))==0)
-    {
-		printf("Data Integrity Test Passed...MD5 Checksum is Same for Both Files\n");
-	}
-	
-	else
-	{
-		printf("Data Integrity Test Failed...MD5 Checksum is Not Same for Both Files\n");
-	}
-	
-	g_free(result_1);
-	g_free(result_2);
-    
-}
 
- 
+    if(strcmp(reinterpret_cast<char*>(result_1),reinterpret_cast<char*>(result_2))==0) {
+        printf("Data Integrity Test Passed...MD5 Checksum is Same for Both Files\n");
+    } else {
+        printf("Data Integrity Test Failed...MD5 Checksum is Not Same for Both Files\n");
+    }
+
+    g_free(result_1);
+    g_free(result_2);
+}

--- a/test/metadata_tests.cpp
+++ b/test/metadata_tests.cpp
@@ -1,0 +1,43 @@
+#include <stdbool.h>
+#include <stdio.h>
+#include "ds3.h"
+#include "test.h"
+#include <boost/test/unit_test.hpp>
+
+BOOST_AUTO_TEST_CASE( put_metadata ) {
+    ds3_error* error;
+    ds3_bulk_object_list* obj_list;
+    ds3_bulk_response* bulk_response;
+    const char* file_name[1] = {"resources/beowulf.txt"};
+    ds3_client* client = get_client();
+    const char* bucket_name = "metadata_test";
+    FILE* file;
+    ds3_request* request = ds3_init_put_bucket(bucket_name);
+
+    error = ds3_put_bucket(client, request);
+    ds3_free_request(request);
+    handle_error(error);
+
+    obj_list = ds3_convert_file_list(file_name, 1);
+
+    request = ds3_init_put_bulk(bucket_name, obj_list);
+    error = ds3_bulk(client, request, &bulk_response);
+    ds3_free_request(request);
+    ds3_free_bulk_object_list(obj_list);
+
+    handle_error(error);
+
+    request = ds3_init_put_object_for_job(bucket_name, "resources/beowulf.txt", 0, obj_list->list[0].length, bulk_response->job_id->value);
+
+    ds3_request_set_metadata(request, "name", "value");
+
+    file = fopen(obj_list->list[0].name->value, "r");
+
+    error = ds3_put_object(client, request, file, ds3_read_from_file);
+    ds3_free_request(request);
+    handle_error(error);
+
+    ds3_free_bulk_response(bulk_response);
+    clear_bucket(client, bucket_name);
+    free_client(client);
+}

--- a/test/metadata_tests.cpp
+++ b/test/metadata_tests.cpp
@@ -1,5 +1,6 @@
 #include <stdbool.h>
 #include <stdio.h>
+#include <glib.h>
 #include "ds3.h"
 #include "test.h"
 #include <boost/test/unit_test.hpp>
@@ -7,7 +8,10 @@
 BOOST_AUTO_TEST_CASE( put_metadata ) {
     ds3_error* error;
     ds3_bulk_object_list* obj_list;
+    uint64_t metadata_count;
     ds3_bulk_response* bulk_response;
+    ds3_metadata* metadata_result;
+    ds3_metadata_entry* metadata_entry;
     const char* file_name[1] = {"resources/beowulf.txt"};
     ds3_client* client = get_client();
     const char* bucket_name = "metadata_test";
@@ -23,21 +27,41 @@ BOOST_AUTO_TEST_CASE( put_metadata ) {
     request = ds3_init_put_bulk(bucket_name, obj_list);
     error = ds3_bulk(client, request, &bulk_response);
     ds3_free_request(request);
-    ds3_free_bulk_object_list(obj_list);
 
     handle_error(error);
 
     request = ds3_init_put_object_for_job(bucket_name, "resources/beowulf.txt", 0, obj_list->list[0].length, bulk_response->job_id->value);
+    file = fopen(obj_list->list[0].name->value, "r");
+    ds3_free_bulk_object_list(obj_list);
 
     ds3_request_set_metadata(request, "name", "value");
-
-    file = fopen(obj_list->list[0].name->value, "r");
 
     error = ds3_put_object(client, request, file, ds3_read_from_file);
     ds3_free_request(request);
     handle_error(error);
 
     ds3_free_bulk_response(bulk_response);
+
+    request = ds3_init_head_object(bucket_name, "resources/beowulf.txt");
+
+    error = ds3_head_object(client, request, &metadata_result);
+    ds3_free_request(request);
+    handle_error(error);
+
+    BOOST_REQUIRE(metadata_result != NULL);
+
+    metadata_count = ds3_metadata_size(metadata_result);
+
+    BOOST_CHECK(metadata_count == 1);
+
+    metadata_entry = ds3_metadata_get_entry(metadata_result, "name");
+
+    BOOST_REQUIRE(metadata_entry != NULL);
+
+    BOOST_CHECK(g_strcmp0(metadata_entry->name->value, "name") == 0);
+
+    ds3_free_metadata_entry(metadata_entry);
+    ds3_free_metadata(metadata_result);
     clear_bucket(client, bucket_name);
     free_client(client);
 }

--- a/test/metadata_tests.cpp
+++ b/test/metadata_tests.cpp
@@ -124,3 +124,74 @@ BOOST_AUTO_TEST_CASE( put_multiple_metadata_items ) {
     clear_bucket(client, bucket_name);
     free_client(client);
 }
+
+static bool contains_key(const ds3_metadata_keys_result* metadata_keys, const char* key) {
+    uint64_t i;
+    for (i = 0; i < metadata_keys->num_keys; i++) {
+        if (g_strcmp0(key, metadata_keys->keys[i]->value) == 0) {
+            return TRUE;
+        }
+    }
+    return FALSE;
+}
+
+BOOST_AUTO_TEST_CASE( metadata_keys ) {
+    ds3_error* error;
+    ds3_bulk_object_list* obj_list;
+    uint64_t metadata_count;
+    ds3_bulk_response* bulk_response;
+    ds3_metadata* metadata_result = NULL;
+    ds3_metadata_keys_result* metadata_keys = NULL;
+
+    const char* file_name[1] = {"resources/beowulf.txt"};
+    ds3_client* client = get_client_at_loglvl(DS3_DEBUG);
+    const char* bucket_name = "key_metadata_test";
+    FILE* file;
+    ds3_request* request = ds3_init_put_bucket(bucket_name);
+
+    error = ds3_put_bucket(client, request);
+    ds3_free_request(request);
+    handle_error(error);
+
+    obj_list = ds3_convert_file_list(file_name, 1);
+
+    request = ds3_init_put_bulk(bucket_name, obj_list);
+    error = ds3_bulk(client, request, &bulk_response);
+    ds3_free_request(request);
+
+    handle_error(error);
+
+    request = ds3_init_put_object_for_job(bucket_name, "resources/beowulf.txt", 0, obj_list->list[0].length, bulk_response->job_id->value);
+    file = fopen(obj_list->list[0].name->value, "r");
+    ds3_free_bulk_object_list(obj_list);
+
+    ds3_request_set_metadata(request, "key", "value2");
+    ds3_request_set_metadata(request, "name", "value");
+
+    error = ds3_put_object(client, request, file, ds3_read_from_file);
+    ds3_free_request(request);
+    handle_error(error);
+    ds3_free_bulk_response(bulk_response);
+
+    request = ds3_init_head_object(bucket_name, "resources/beowulf.txt");
+
+    error = ds3_head_object(client, request, &metadata_result);
+    ds3_free_request(request);
+    handle_error(error);
+    BOOST_REQUIRE(metadata_result != NULL);
+
+    metadata_count = ds3_metadata_size(metadata_result);
+    BOOST_CHECK(metadata_count == 2);
+
+    metadata_keys = ds3_metadata_keys(metadata_result);
+    BOOST_REQUIRE(metadata_keys != NULL);
+
+    BOOST_CHECK(metadata_keys->num_keys == 2);
+    BOOST_CHECK(contains_key(metadata_keys, "key"));
+    BOOST_CHECK(contains_key(metadata_keys, "name"));
+
+    ds3_free_metadata_keys(metadata_keys);
+    ds3_free_metadata(metadata_result);
+    clear_bucket(client, bucket_name);
+    free_client(client);
+}

--- a/test/metadata_tests.cpp
+++ b/test/metadata_tests.cpp
@@ -39,7 +39,6 @@ BOOST_AUTO_TEST_CASE( put_metadata ) {
     error = ds3_put_object(client, request, file, ds3_read_from_file);
     ds3_free_request(request);
     handle_error(error);
-
     ds3_free_bulk_response(bulk_response);
 
     request = ds3_init_head_object(bucket_name, "resources/beowulf.txt");
@@ -47,18 +46,78 @@ BOOST_AUTO_TEST_CASE( put_metadata ) {
     error = ds3_head_object(client, request, &metadata_result);
     ds3_free_request(request);
     handle_error(error);
-
     BOOST_REQUIRE(metadata_result != NULL);
 
     metadata_count = ds3_metadata_size(metadata_result);
-
     BOOST_CHECK(metadata_count == 1);
 
     metadata_entry = ds3_metadata_get_entry(metadata_result, "name");
-
     BOOST_REQUIRE(metadata_entry != NULL);
-
     BOOST_CHECK(g_strcmp0(metadata_entry->name->value, "name") == 0);
+
+    ds3_free_metadata_entry(metadata_entry);
+    ds3_free_metadata(metadata_result);
+    clear_bucket(client, bucket_name);
+    free_client(client);
+}
+
+BOOST_AUTO_TEST_CASE( put_multiple_metadata_items ) {
+    ds3_error* error;
+    ds3_bulk_object_list* obj_list;
+    uint64_t metadata_count;
+    ds3_bulk_response* bulk_response;
+    ds3_metadata* metadata_result;
+    ds3_metadata_entry* metadata_entry;
+    const char* file_name[1] = {"resources/beowulf.txt"};
+    ds3_client* client = get_client_at_loglvl(DS3_DEBUG);
+    const char* bucket_name = "multi_metadata_test";
+    FILE* file;
+    ds3_request* request = ds3_init_put_bucket(bucket_name);
+
+    error = ds3_put_bucket(client, request);
+    ds3_free_request(request);
+    handle_error(error);
+
+    obj_list = ds3_convert_file_list(file_name, 1);
+
+    request = ds3_init_put_bulk(bucket_name, obj_list);
+    error = ds3_bulk(client, request, &bulk_response);
+    ds3_free_request(request);
+
+    handle_error(error);
+
+    request = ds3_init_put_object_for_job(bucket_name, "resources/beowulf.txt", 0, obj_list->list[0].length, bulk_response->job_id->value);
+    file = fopen(obj_list->list[0].name->value, "r");
+    ds3_free_bulk_object_list(obj_list);
+
+    ds3_request_set_metadata(request, "key", "value2");
+    ds3_request_set_metadata(request, "name", "value");
+
+    error = ds3_put_object(client, request, file, ds3_read_from_file);
+    ds3_free_request(request);
+    handle_error(error);
+    ds3_free_bulk_response(bulk_response);
+
+    request = ds3_init_head_object(bucket_name, "resources/beowulf.txt");
+
+    error = ds3_head_object(client, request, &metadata_result);
+    ds3_free_request(request);
+    handle_error(error);
+    BOOST_REQUIRE(metadata_result != NULL);
+
+    metadata_count = ds3_metadata_size(metadata_result);
+    BOOST_CHECK(metadata_count == 2);
+
+    metadata_entry = ds3_metadata_get_entry(metadata_result, "name");
+    BOOST_REQUIRE(metadata_entry != NULL);
+    BOOST_CHECK(g_strcmp0(metadata_entry->name->value, "name") == 0);
+    BOOST_CHECK(g_strcmp0(metadata_entry->values[0]->value, "value") == 0);
+    ds3_free_metadata_entry(metadata_entry);
+
+    metadata_entry = ds3_metadata_get_entry(metadata_result, "key");
+    BOOST_REQUIRE(metadata_entry != NULL);
+    BOOST_CHECK(g_strcmp0(metadata_entry->name->value, "key") == 0);
+    BOOST_CHECK(g_strcmp0(metadata_entry->values[0]->value, "value2") == 0);
 
     ds3_free_metadata_entry(metadata_entry);
     ds3_free_metadata(metadata_result);

--- a/test/metadata_tests.cpp
+++ b/test/metadata_tests.cpp
@@ -38,6 +38,7 @@ BOOST_AUTO_TEST_CASE( put_metadata ) {
 
     error = ds3_put_object(client, request, file, ds3_read_from_file);
     ds3_free_request(request);
+    fclose(file);
     handle_error(error);
     ds3_free_bulk_response(bulk_response);
 
@@ -83,7 +84,6 @@ BOOST_AUTO_TEST_CASE( put_multiple_metadata_items ) {
     request = ds3_init_put_bulk(bucket_name, obj_list);
     error = ds3_bulk(client, request, &bulk_response);
     ds3_free_request(request);
-
     handle_error(error);
 
     request = ds3_init_put_object_for_job(bucket_name, "resources/beowulf.txt", 0, obj_list->list[0].length, bulk_response->job_id->value);
@@ -95,6 +95,7 @@ BOOST_AUTO_TEST_CASE( put_multiple_metadata_items ) {
 
     error = ds3_put_object(client, request, file, ds3_read_from_file);
     ds3_free_request(request);
+    fclose(file);
     handle_error(error);
     ds3_free_bulk_response(bulk_response);
 
@@ -158,7 +159,6 @@ BOOST_AUTO_TEST_CASE( metadata_keys ) {
     request = ds3_init_put_bulk(bucket_name, obj_list);
     error = ds3_bulk(client, request, &bulk_response);
     ds3_free_request(request);
-
     handle_error(error);
 
     request = ds3_init_put_object_for_job(bucket_name, "resources/beowulf.txt", 0, obj_list->list[0].length, bulk_response->job_id->value);
@@ -170,6 +170,7 @@ BOOST_AUTO_TEST_CASE( metadata_keys ) {
 
     error = ds3_put_object(client, request, file, ds3_read_from_file);
     ds3_free_request(request);
+    fclose(file);
     handle_error(error);
     ds3_free_bulk_response(bulk_response);
 
@@ -191,6 +192,68 @@ BOOST_AUTO_TEST_CASE( metadata_keys ) {
     BOOST_CHECK(contains_key(metadata_keys, "name"));
 
     ds3_free_metadata_keys(metadata_keys);
+    ds3_free_metadata(metadata_result);
+    clear_bucket(client, bucket_name);
+    free_client(client);
+}
+
+BOOST_AUTO_TEST_CASE( put_metadata_using_get_object_retrieval ) {
+    ds3_error* error;
+    ds3_bulk_object_list* obj_list;
+    uint64_t metadata_count;
+    ds3_bulk_response* bulk_response;
+    ds3_metadata* metadata_result;
+    ds3_metadata_entry* metadata_entry;
+    const char* file_name[1] = {"resources/beowulf.txt"};
+    ds3_client* client = get_client();
+    const char* bucket_name = "get_object_metadata_test";
+    FILE* file;
+    ds3_request* request = ds3_init_put_bucket(bucket_name);
+
+    error = ds3_put_bucket(client, request);
+    ds3_free_request(request);
+    handle_error(error);
+
+    obj_list = ds3_convert_file_list(file_name, 1);
+
+    request = ds3_init_put_bulk(bucket_name, obj_list);
+    error = ds3_bulk(client, request, &bulk_response);
+    ds3_free_request(request);
+    handle_error(error);
+
+    request = ds3_init_put_object_for_job(bucket_name, "resources/beowulf.txt", 0, obj_list->list[0].length, bulk_response->job_id->value);
+    file = fopen(obj_list->list[0].name->value, "r");
+
+    ds3_request_set_metadata(request, "name", "value");
+    error = ds3_put_object(client, request, file, ds3_read_from_file);
+    ds3_free_request(request);
+    fclose(file);
+    handle_error(error);
+    ds3_free_bulk_response(bulk_response);
+
+    request = ds3_init_get_bulk(bucket_name, obj_list, NONE);
+    error = ds3_bulk(client, request, &bulk_response);
+    ds3_free_request(request);
+    ds3_free_bulk_object_list(obj_list);
+    handle_error(error);
+
+    request = ds3_init_get_object_for_job(bucket_name, "resources/beowulf.txt", 0, bulk_response->job_id->value);
+    file = fopen("/dev/null", "w");
+    error = ds3_get_object_with_metadata(client, request, file, ds3_write_to_file, &metadata_result);
+    ds3_free_request(request);
+    ds3_free_bulk_response(bulk_response);
+    fclose(file);
+    handle_error(error);
+    BOOST_REQUIRE(metadata_result != NULL);
+
+    metadata_count = ds3_metadata_size(metadata_result);
+    BOOST_CHECK(metadata_count == 1);
+
+    metadata_entry = ds3_metadata_get_entry(metadata_result, "name");
+    BOOST_REQUIRE(metadata_entry != NULL);
+    BOOST_CHECK(g_strcmp0(metadata_entry->name->value, "name") == 0);
+
+    ds3_free_metadata_entry(metadata_entry);
     ds3_free_metadata(metadata_result);
     clear_bucket(client, bucket_name);
     free_client(client);

--- a/test/multimap_tests.cpp
+++ b/test/multimap_tests.cpp
@@ -1,0 +1,15 @@
+#include "ds3_string_multimap.h"
+#include <boost/test/unit_test.hpp>
+#include <glib.h>
+
+BOOST_AUTO_TEST_CASE( basic_put ) {
+    ds3_string_multimap* map = ds3_string_multimap_init();
+
+    ds3_string_multimap_insert(map, "key", "value");
+
+    GPtrArray* values = ds3_string_multimap_lookup(map, "key");
+
+    BOOST_CHECK(g_ptr_array_size(values) == 1);
+
+    ds3_string_multimap_free(map);
+}

--- a/test/negative_tests.cpp
+++ b/test/negative_tests.cpp
@@ -247,50 +247,49 @@ BOOST_AUTO_TEST_CASE( put_empty_object_list) {
     handle_error(error);
 }
 
-BOOST_AUTO_TEST_CASE(delete_multiple_job){
-	printf("-----Testing Multiple Delete Jobs-------\n");
-	ds3_request* request;
-	ds3_error* error;
-	ds3_client* client = get_client();
-	const char* bucket_name = "bucket_test_get_job";
+BOOST_AUTO_TEST_CASE(delete_multiple_job) {
+    printf("-----Testing Multiple Delete Jobs-------\n");
+    ds3_request* request;
+    ds3_error* error;
+    ds3_client* client = get_client();
+    const char* bucket_name = "bucket_test_get_job";
 
-	ds3_str* job_id = populate_with_objects_return_job(client, bucket_name);
-	request = ds3_init_delete_job(job_id->value);
-	error = ds3_delete_job(client,request);
-	handle_error(error);
+    ds3_str* job_id = populate_with_objects_return_job(client, bucket_name);
+    request = ds3_init_delete_job(job_id->value);
+    error = ds3_delete_job(client,request);
+    handle_error(error);
 
-	error = ds3_delete_job(client,request);
+    error = ds3_delete_job(client,request);
     BOOST_CHECK(error != NULL);
     BOOST_CHECK(error->error->status_code == 404);
     BOOST_CHECK(strcmp(error->error->status_message->value ,"Not Found")==0);
     ds3_free_error(error);
 
-	ds3_free_request(request);
-	ds3_str_free(job_id);
+    ds3_free_request(request);
+    ds3_str_free(job_id);
     clear_bucket(client, bucket_name);
     free_client(client);
-	
+
 }
 
-BOOST_AUTO_TEST_CASE(get_non_existing_job){
-	printf("-----Testing Non Existing Get Job-------\n");
-	ds3_request* request;
-	ds3_error* error;
-	ds3_bulk_response* bulk_response = NULL;
-	ds3_client* client = get_client();
-	request = ds3_init_get_job("b44d7ddc-608a-4d46-9e9e-9433b0b62911");
-	error = ds3_get_job(client,request,&bulk_response);
-	BOOST_CHECK(error != NULL);
+BOOST_AUTO_TEST_CASE(get_non_existing_job) {
+    printf("-----Testing Non Existing Get Job-------\n");
+    ds3_request* request;
+    ds3_error* error;
+    ds3_bulk_response* bulk_response = NULL;
+    ds3_client* client = get_client();
+    request = ds3_init_get_job("b44d7ddc-608a-4d46-9e9e-9433b0b62911");
+    error = ds3_get_job(client,request,&bulk_response);
+    BOOST_CHECK(error != NULL);
     BOOST_CHECK(error->error->status_code == 404);
     BOOST_CHECK(strcmp(error->error->status_message->value ,"Not Found")==0);
     ds3_free_error(error);
-	ds3_free_request(request);
-	ds3_free_bulk_response(bulk_response);
-	free_client(client);
+    ds3_free_request(request);
+    ds3_free_bulk_response(bulk_response);
+    free_client(client);
 }
 
-BOOST_AUTO_TEST_CASE(bad_checksum)
-{
+BOOST_AUTO_TEST_CASE(bad_checksum) {
     printf("-----Testing Request With Bad Checksum-------\n");
     uint64_t i, n;
     const char* bucket_name = "bucket_test_md5";
@@ -311,8 +310,6 @@ BOOST_AUTO_TEST_CASE(bad_checksum)
     ds3_free_request(request);
     handle_error(error);
 
- 
-
     for (n = 0; n < response->list_size; n ++) {
 
       request = ds3_init_allocate_chunk(response->list[n]->chunk_id->value);
@@ -331,17 +328,17 @@ BOOST_AUTO_TEST_CASE(bad_checksum)
 
           request = ds3_init_put_object_for_job(bucket_name, bulk_object.name->value, bulk_object.offset,  bulk_object.length, response->job_id->value);
           ds3_request_set_md5(request,"a%4sgh");
-         
+
           if (bulk_object.offset > 0) {
               fseek(file, bulk_object.offset, SEEK_SET);
           }
-        
+
           error = ds3_put_object(client, request, file, ds3_read_from_file);
           ds3_free_request(request);
           fclose(file);
-          BOOST_REQUIRE(error != NULL);         
-		  BOOST_CHECK(error->error->status_code == 403);
-		  BOOST_CHECK(strcmp(error->error->status_message->value ,"Forbidden")==0);
+          BOOST_REQUIRE(error != NULL);
+          BOOST_CHECK(error->error->status_code == 403);
+          BOOST_CHECK(strcmp(error->error->status_message->value ,"Forbidden")==0);
           ds3_free_error(error);
       }
       ds3_free_allocate_chunk_response(chunk_response);

--- a/test/negative_tests.cpp
+++ b/test/negative_tests.cpp
@@ -289,6 +289,8 @@ BOOST_AUTO_TEST_CASE(get_non_existing_job) {
     free_client(client);
 }
 
+/* TODO uncomment this when using the latest simulator
+
 BOOST_AUTO_TEST_CASE(bad_checksum) {
     printf("-----Testing Request With Bad Checksum-------\n");
     uint64_t i, n;
@@ -348,3 +350,5 @@ BOOST_AUTO_TEST_CASE(bad_checksum) {
     clear_bucket(client, bucket_name);
     free_client(client);
 }
+
+*/

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -105,7 +105,7 @@ ds3_str* populate_with_empty_objects(const ds3_client* client, const char* bucke
     ds3_free_request(request);
     handle_error(error);
     job_id = ds3_str_dup(response->job_id);
-  
+
     ds3_free_bulk_response(response);
     ds3_free_bulk_object_list(obj_list);
     return job_id;

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -20,8 +20,8 @@ void test_log(const char* message, void* user_data) {
     fprintf(stderr, "Log Message: %s\n", message);
 }
 
-ds3_client* get_client() {
-    ds3_client* client;
+ds3_client* get_client_at_loglvl(ds3_log_lvl log_lvl) {
+  ds3_client* client;
 
     ds3_error* error = ds3_create_client_from_env(&client);
 
@@ -31,9 +31,13 @@ ds3_client* get_client() {
         BOOST_FAIL("Failed to setup client.");
     }
 
-    ds3_client_register_logging(client, DS3_INFO, test_log, NULL);
+    ds3_client_register_logging(client, log_lvl, test_log, NULL);
 
     return client;
+}
+
+ds3_client* get_client() {
+    return get_client_at_loglvl(DS3_INFO);
 }
 
 void print_error(const ds3_error* error) {

--- a/test/test.h
+++ b/test/test.h
@@ -4,6 +4,7 @@
 #define __DS3_TEST__
 
 ds3_client* get_client();
+ds3_client* get_client_at_loglvl(ds3_log_lvl lvl);
 void clear_bucket(const ds3_client* client, const char* bucket_name);
 void populate_with_objects(const ds3_client* client, const char* bucket_name);
 ds3_str* populate_with_objects_return_job(const ds3_client* client, const char* bucket_name);


### PR DESCRIPTION
Adding metadata support to the C SDK.  Added the head object call so that we can retrieve metadata information without having to get the object.  Added a `get_object_with_metadata` call so that metadata can be retrieved when getting an object.

Added integration tests for all the new calls, and verified that no new memory is leaked with valgrind.