### PR TITLE
Csdk 74: Add callback to ds3_client for net_callback, and refactor out GHashTable from ds3_net.c::net_process_request()

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,7 +1,7 @@
 lib_LTLIBRARIES = libds3.la
-include_HEADERS = ds3.h ds3_string_multimap.h ds3_net.h ds3_request.h ds3_utils.h ds3_string_multimap_impl.h
+include_HEADERS = ds3.h ds3_string_multimap.h ds3_net.h ds3_request.h ds3_utils.h ds3_string_multimap_impl.h ds3_string.h
 
-libds3_la_SOURCES = ds3.c ds3_string_multimap.c ds3_net.c ds3_request.c ds3_string_multimap_impl.c
+libds3_la_SOURCES = ds3.c ds3_string_multimap.c ds3_net.c ds3_string_multimap_impl.c
 libds3_la_CFLAGS = $(LIBXML2_CFLAGS) $(GLIB2_CFLAGS) $(LIBCURL_CFLAGS) -Wall
 libds3_la_LIBADD = $(LIBXML2_LIBS) $(GLIB2_LIBS) $(LIBCURL_LIBS)
 libds3_la_LDFLAGS = -version-info 0:0:0

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,7 +1,7 @@
 lib_LTLIBRARIES = libds3.la
 include_HEADERS = ds3.h ds3_string_multimap.h ds3_net.h ds3_request.h ds3_utils.h ds3_string_multimap_impl.h
 
-libds3_la_SOURCES = ds3.c ds3_string_multimap.c ds3_net.c ds3_string_multimap_impl.c
+libds3_la_SOURCES = ds3.c ds3_string_multimap.c ds3_net.c ds3_request.c ds3_string_multimap_impl.c
 libds3_la_CFLAGS = $(LIBXML2_CFLAGS) $(GLIB2_CFLAGS) $(LIBCURL_CFLAGS) -Wall
 libds3_la_LIBADD = $(LIBXML2_LIBS) $(GLIB2_LIBS) $(LIBCURL_LIBS)
 libds3_la_LDFLAGS = -version-info 0:0:0

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,7 +1,7 @@
 lib_LTLIBRARIES = libds3.la
-include_HEADERS = ds3.h ds3_string_multimap.h ds3_net.h ds3_request.h ds3_utils.h
+include_HEADERS = ds3.h ds3_string_multimap.h ds3_net.h ds3_request.h ds3_utils.h ds3_string_multimap_impl.h
 
-libds3_la_SOURCES = ds3.c ds3_string_multimap.c ds3_net.c
+libds3_la_SOURCES = ds3.c ds3_string_multimap.c ds3_net.c ds3_string_multimap_impl.c
 libds3_la_CFLAGS = $(LIBXML2_CFLAGS) $(GLIB2_CFLAGS) $(LIBCURL_CFLAGS) -Wall
 libds3_la_LIBADD = $(LIBXML2_LIBS) $(GLIB2_LIBS) $(LIBCURL_LIBS)
 libds3_la_LDFLAGS = -version-info 0:0:0

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,7 +1,7 @@
 lib_LTLIBRARIES = libds3.la
 include_HEADERS = ds3.h ds3_string_multimap.h ds3_net.h ds3_request.h ds3_utils.h ds3_string_multimap_impl.h ds3_string.h
 
-libds3_la_SOURCES = ds3.c ds3_string_multimap.c ds3_net.c ds3_string_multimap_impl.c
+libds3_la_SOURCES = ds3.c ds3_string_multimap.c ds3_net.c ds3_string_multimap_impl.c ds3_string.c
 libds3_la_CFLAGS = $(LIBXML2_CFLAGS) $(GLIB2_CFLAGS) $(LIBCURL_CFLAGS) -Wall
 libds3_la_LIBADD = $(LIBXML2_LIBS) $(GLIB2_LIBS) $(LIBCURL_LIBS)
 libds3_la_LDFLAGS = -version-info 0:0:0

--- a/src/ds3.c
+++ b/src/ds3.c
@@ -1309,7 +1309,7 @@ ds3_error* ds3_get_object(const ds3_client* client, const ds3_request* request, 
 
 ds3_error* ds3_get_object_with_metadata(const ds3_client* client, const ds3_request* request, void* user_data, size_t (* callback)(void*, size_t, size_t, void*), ds3_metadata** _metadata) {
     ds3_error* error;
-    struct _ds3_map* return_headers;
+    ds3_map* return_headers;
     ds3_metadata* metadata;
 
     error = net_process_request(client, request, user_data, callback, NULL, NULL, &return_headers);
@@ -2141,6 +2141,7 @@ ds3_error* ds3_allocate_chunk(const ds3_client* client, const ds3_request* reque
     error = net_process_request(client, request, xml_blob, ds3_load_buffer, NULL, NULL, &response_headers);
 
     if (error != NULL) {
+        ds3_map_free(response_headers);
         g_byte_array_free(xml_blob, TRUE);
         return error;
     }
@@ -2179,9 +2180,7 @@ ds3_error* ds3_allocate_chunk(const ds3_client* client, const ds3_request* reque
 
     xmlFreeDoc(doc);
     g_byte_array_free(xml_blob, TRUE);
-    if (response_headers != NULL) {
-        ds3_map_free(response_headers);
-    }
+    ds3_map_free(response_headers);
     *response = ds3_response;
     return NULL;
 }
@@ -2198,9 +2197,7 @@ ds3_error* ds3_get_available_chunks(const ds3_client* client, const ds3_request*
     error = net_process_request(client, request, xml_blob, ds3_load_buffer, NULL, NULL, &response_headers);
 
     if (error != NULL) {
-        if (response_headers != NULL) {
-            ds3_map_free(response_headers);
-        }
+        ds3_map_free(response_headers);
         g_byte_array_free(xml_blob, TRUE);
         return error;
     }
@@ -2222,9 +2219,7 @@ ds3_error* ds3_get_available_chunks(const ds3_client* client, const ds3_request*
 
     xmlFreeDoc(doc);
     g_byte_array_free(xml_blob, TRUE);
-    if (response_headers != NULL) {
-        ds3_map_free(response_headers);
-    }
+    ds3_map_free(response_headers);
     *response = ds3_response;
     return NULL;
 }
@@ -2279,10 +2274,9 @@ ds3_error* ds3_get_jobs(const ds3_client* client, const ds3_request* request, ds
     ds3_error* error;
     GByteArray* xml_blob = g_byte_array_new();
     ds3_get_jobs_response* get_jobs_response = NULL;
-    ds3_map* response_headers;
     xmlDocPtr doc;
 
-    error = net_process_request(client, request, xml_blob, ds3_load_buffer, NULL, NULL, &response_headers);
+    error = net_process_request(client, request, xml_blob, ds3_load_buffer, NULL, NULL, NULL);
     if (error != NULL) {
         g_byte_array_free(xml_blob, TRUE);
         return error;
@@ -2298,9 +2292,6 @@ ds3_error* ds3_get_jobs(const ds3_client* client, const ds3_request* request, ds
 
     xmlFreeDoc(doc);
     g_byte_array_free(xml_blob, TRUE);
-    if (response_headers != NULL) {
-        ds3_map_free(response_headers);
-    }
     *response = get_jobs_response;
     return NULL;
 }

--- a/src/ds3.c
+++ b/src/ds3.c
@@ -1274,7 +1274,7 @@ static int num_chars_in_ds3_str(const ds3_str* str, char ch) {
 
 ds3_error* ds3_head_object(const ds3_client* client, const ds3_request* request, ds3_metadata** _metadata) {
     ds3_error* error;
-    struct _ds3_map* return_headers;
+    ds3_map* return_headers;
     ds3_metadata* metadata = NULL;
 
     if (num_chars_in_ds3_str(request->path, '/') < 2){

--- a/src/ds3.c
+++ b/src/ds3.c
@@ -330,6 +330,21 @@ ds3_creds* ds3_create_creds(const char* access_id, const char* secret_key) {
     return creds;
 }
 
+void ds3_client_register_net(ds3_client* client, ds3_error* (* net_callback)(const ds3_client* client,
+                                                                        const ds3_request* _request,
+                                                                        void* read_user_struct,
+                                                                        size_t (*read_handler_func)(void*, size_t, size_t, void*),
+                                                                        void* write_user_struct,
+                                                                        size_t (*write_handler_func)(void*, size_t, size_t, void*),
+                                                                        GHashTable** return_headers)) {
+    if (client == NULL) {
+        fprintf(stderr, "Cannot configure a null ds3_client for net_callback.\n");
+        return;
+    }
+
+    client->net_callback = net_callback;
+}
+
 ds3_client* ds3_create_client(const char* endpoint, ds3_creds* creds) {
     ds3_client* client;
     if (endpoint == NULL) {
@@ -344,6 +359,9 @@ ds3_client* ds3_create_client(const char* endpoint, ds3_creds* creds) {
     client->creds = creds;
 
     client->num_redirects = 5L; //default to 5 redirects before failing
+
+    ds3_client_register_net( client, &net_process_request );
+
     return client;
 }
 

--- a/src/ds3.c
+++ b/src/ds3.c
@@ -124,14 +124,12 @@ static ds3_metadata_entry* ds3_metadata_entry_init(ds3_string_multimap_entry* he
     unsigned int num_values = ds3_string_multimap_entry_get_num_values(header_entry);
     for (i = 0; i < num_values; i++) {
         header_value = ds3_string_multimap_entry_get_value_by_index(header_entry, i);
-        g_ptr_array_add(values, ds3_str_dup(header_value));
+        g_ptr_array_add(values, header_value);
     }
 
     ds3_str* full_key = ds3_string_multimap_entry_get_key(header_entry);
-    printf("full_key[%s]\n", full_key->value);
     key_name = ds3_str_init(full_key->value + 11); // offset after "x-amz-meta-"
     ds3_str_free(full_key);
-    printf("key[%s]\n", key_name->value);
 
     response->num_values = num_values;
     response->name = key_name;
@@ -163,7 +161,6 @@ static ds3_metadata* _init_metadata(ds3_string_multimap* response_headers) {
     while(g_hash_table_iter_next(&iter, &_key, &_value)) {
         key = (ds3_str*) _key;
         if (g_str_has_prefix(key->value, "x-amz-meta-")) {
-            printf("\nFound key[%s]\n", key->value);
             ds3_string_multimap_entry* mm_entry = ds3_string_multimap_lookup(response_headers, key);
             entry = ds3_metadata_entry_init(mm_entry);
             g_hash_table_insert(metadata->metadata, g_strdup(entry->name->value), entry);
@@ -2214,6 +2211,8 @@ ds3_error* ds3_get_available_chunks(const ds3_client* client, const ds3_request*
         if (retry_after_header != NULL) {
             ds3_str* retry_value = ds3_string_multimap_entry_get_value_by_index(retry_after_header, 0);
             ds3_response->retry_after = g_ascii_strtoull(retry_value->value, NULL, 10);
+            ds3_string_multimap_entry_free(retry_after_header);
+            ds3_str_free(retry_value);
         }
         ds3_str_free(retry_str);
     }

--- a/src/ds3.h
+++ b/src/ds3.h
@@ -19,6 +19,7 @@
 #include <stdint.h>
 #include <string.h>
 #include <curl/curl.h>
+#include "ds3_string.h"
 #include "ds3_string_multimap.h"
 
 #ifdef __cplusplus
@@ -39,8 +40,6 @@ extern "C" {
 #define DS3_READFUNC_ABORT CURL_READFUNC_ABORT
 
 typedef struct _ds3_request ds3_request;
-
-//typedef struct _ds3_map ds3_map;
 
 typedef enum {
     False, True
@@ -79,11 +78,6 @@ typedef enum {
 typedef enum {
     IN_ORDER, NONE
 }ds3_chunk_ordering;
-
-typedef struct{
-    char* value;
-    size_t size;
-}ds3_str;
 
 typedef enum {
     IN_PROGRESS,

--- a/src/ds3.h
+++ b/src/ds3.h
@@ -19,6 +19,7 @@
 #include <stdint.h>
 #include <string.h>
 #include <curl/curl.h>
+#include "ds3_string_multimap.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -39,7 +40,7 @@ extern "C" {
 
 typedef struct _ds3_request ds3_request;
 
-typedef struct _ds3_map ds3_map;
+//typedef struct _ds3_map ds3_map;
 
 typedef enum {
     False, True
@@ -189,7 +190,7 @@ typedef struct _ds3_client {
                                 size_t (*read_handler_func)(void*, size_t, size_t, void*),
                                 void* write_user_struct,
                                 size_t (*write_handler_func)(void*, size_t, size_t, void*),
-                                ds3_map** return_headers);
+                                ds3_string_multimap** return_headers);
 }ds3_client;
 
 typedef struct {
@@ -384,7 +385,7 @@ LIBRARY_API void        ds3_client_register_net(ds3_client* client, ds3_error* (
                                                                                                 size_t (*read_handler_func)(void*, size_t, size_t, void*),
                                                                                                 void* write_user_struct,
                                                                                                 size_t (*write_handler_func)(void*, size_t, size_t, void*),
-                                                                                                ds3_map** return_headers));
+                                                                                                ds3_string_multimap** return_headers));
 
 LIBRARY_API ds3_request* ds3_init_get_system_information(void);
 LIBRARY_API ds3_request* ds3_init_get_service(void);

--- a/src/ds3.h
+++ b/src/ds3.h
@@ -16,7 +16,6 @@
 #ifndef __DS3_HEADER__
 #define __DS3_HEADER__
 
-#include <glib.h> //TODO remove after pulling out ds3_response_headers_table
 #include <stdint.h>
 #include <string.h>
 #include <curl/curl.h>
@@ -39,6 +38,8 @@ extern "C" {
 #define DS3_READFUNC_ABORT CURL_READFUNC_ABORT
 
 typedef struct _ds3_request ds3_request;
+
+typedef struct _ds3_map ds3_map;
 
 typedef enum {
     False, True
@@ -188,9 +189,8 @@ typedef struct _ds3_client {
                                 size_t (*read_handler_func)(void*, size_t, size_t, void*),
                                 void* write_user_struct,
                                 size_t (*write_handler_func)(void*, size_t, size_t, void*),
-                                GHashTable** return_headers);
+                                ds3_map** return_headers);
 }ds3_client;
-
 
 typedef struct {
     ds3_str* creation_date;
@@ -378,6 +378,13 @@ LIBRARY_API ds3_creds*  ds3_create_creds(const char* access_id, const char* secr
 LIBRARY_API ds3_client* ds3_create_client(const char* endpoint, ds3_creds* creds);
 LIBRARY_API ds3_error*  ds3_create_client_from_env(ds3_client** client);
 LIBRARY_API void        ds3_client_register_logging(ds3_client* client, ds3_log_lvl log_lvl, void (* log_callback)(const char* log_message, void* user_data), void* user_data);
+LIBRARY_API void        ds3_client_register_net(ds3_client* client, ds3_error* (* net_callback)(const ds3_client* client,
+                                                                                                const ds3_request* _request,
+                                                                                                void* read_user_struct,
+                                                                                                size_t (*read_handler_func)(void*, size_t, size_t, void*),
+                                                                                                void* write_user_struct,
+                                                                                                size_t (*write_handler_func)(void*, size_t, size_t, void*),
+                                                                                                ds3_map** return_headers));
 
 LIBRARY_API ds3_request* ds3_init_get_system_information(void);
 LIBRARY_API ds3_request* ds3_init_get_service(void);
@@ -485,6 +492,7 @@ LIBRARY_API ds3_bulk_object_list* ds3_convert_file_list_with_basepath(const char
 LIBRARY_API ds3_bulk_object_list* ds3_convert_object_list(const ds3_object* objects, uint64_t num_objects);
 LIBRARY_API ds3_bulk_object_list* ds3_init_bulk_object_list(uint64_t num_files);
 LIBRARY_API void ds3_free_bulk_object_list(ds3_bulk_object_list* object_list);
+
 
 #ifdef __cplusplus
 }

--- a/src/ds3.h
+++ b/src/ds3.h
@@ -129,13 +129,6 @@ typedef enum {
   DATA, FOLDER
 }ds3_object_type;
 
-LIBRARY_API ds3_str* ds3_str_init(const char* string);
-LIBRARY_API ds3_str* ds3_str_init_with_size(const char* string, size_t size);
-LIBRARY_API char* ds3_str_value(const ds3_str* string);
-LIBRARY_API size_t ds3_str_size(const ds3_str* string);
-LIBRARY_API ds3_str* ds3_str_dup(const ds3_str* string);
-LIBRARY_API void ds3_str_free(ds3_str* string);
-
 typedef enum {
   DS3_ERROR, DS3_WARN, DS3_INFO, DS3_DEBUG, DS3_TRACE
 }ds3_log_lvl;

--- a/src/ds3_net.c
+++ b/src/ds3_net.c
@@ -389,7 +389,13 @@ static size_t _process_response_body(void* buffer, size_t size, size_t nmemb, vo
     }
 }
 
-ds3_error* net_process_request(const ds3_client* client, const ds3_request* _request, void* read_user_struct, size_t (*read_handler_func)(void*, size_t, size_t, void*), void* write_user_struct, size_t (*write_handler_func)(void*, size_t, size_t, void*), GHashTable** return_headers) {
+ds3_error* net_process_request(const ds3_client* client,
+                               const ds3_request* _request,
+                               void* read_user_struct,
+                               size_t (*read_handler_func)(void*, size_t, size_t, void*),
+                               void* write_user_struct,
+                               size_t (*write_handler_func)(void*, size_t, size_t, void*),
+                               GHashTable** return_headers) {
     struct _ds3_request* request = (struct _ds3_request*) _request;
     CURL* handle;
     CURLcode res;

--- a/src/ds3_net.c
+++ b/src/ds3_net.c
@@ -281,7 +281,6 @@ static size_t _process_header_line(void* buffer, size_t size, size_t nmemb, void
     ds3_str* header_key;
     ds3_str* header_value;
     ds3_response_data* response_data = (ds3_response_data*) user_data;
-    GHashTable* headers = ds3_string_multimap_get_hashtable(response_data->headers);
 
     to_read = size * nmemb;
     if (to_read < 2) {
@@ -332,7 +331,7 @@ static size_t _process_header_line(void* buffer, size_t size, size_t nmemb, void
         header_key = ds3_str_init(split_result[0]);
         header_value = ds3_str_init(split_result[1]);
 
-        ds3_string_multimap_insert(headers, header_key, header_value);
+        ds3_string_multimap_insert(response_data->headers, header_key, header_value);
 
         ds3_str_free(header_key);
         ds3_str_free(header_value);
@@ -545,12 +544,11 @@ ds3_error* net_process_request(const ds3_client* client,
             g_byte_array_free(response_data.body, TRUE);
             ds3_str_free(response_data.status_message);
 
-            if (return_headers == NULL) {
+            if (return_headers != NULL) {
                 *return_headers = response_headers;
             } else {
                 ds3_string_multimap_free(response_headers);
             }
-            ds3_string_multimap_free(response_headers);
 
             break;
         } else {

--- a/src/ds3_net.c
+++ b/src/ds3_net.c
@@ -332,7 +332,6 @@ static size_t _process_header_line(void* buffer, size_t size, size_t nmemb, void
         header_value = ds3_str_init(split_result[1]);
 
         ds3_string_multimap_insert(response_data->headers, header_key, header_value);
-
         ds3_str_free(header_key);
         ds3_str_free(header_value);
         g_strfreev(split_result);

--- a/src/ds3_net.c
+++ b/src/ds3_net.c
@@ -272,18 +272,6 @@ static char* _canonicalized_resource(ds3_str* path, GHashTable* query_params) {
     }
 }
 
-static void _ds3_free_response_header(gpointer data) {
-    ds3_response_header* header;
-    if (data == NULL) {
-        return;
-    }
-
-    header = (ds3_response_header*) data;
-    ds3_str_free(header->key);
-    g_ptr_array_free(header->values, TRUE);
-    g_free(data);
-}
-
 /* This is used to free the entires in the values ptr array in the ds3_response_header
  */
 static void _ds3_internal_str_free(gpointer data) {
@@ -295,6 +283,41 @@ static ds3_response_header* _ds3_init_response_header(const ds3_str* key) {
     header->key = ds3_str_dup(key);
     header->values = g_ptr_array_new_with_free_func(_ds3_internal_str_free);
     return header;
+}
+
+void ds3_free_response_header(gpointer data) {
+    ds3_response_header* header;
+    if (data == NULL) {
+        return;
+    }
+
+    header = (ds3_response_header*) data;
+    ds3_str_free(header->key);
+    g_ptr_array_free(header->values, TRUE);
+    g_free(data);
+}
+
+ds3_map* ds3_map_init() {
+    struct _ds3_map* map = g_new0(struct _ds3_map, 1);
+    map->map = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, ds3_free_response_header);
+    return (ds3_map*)map;
+}
+
+ds3_response_header* ds3_map_lookup(ds3_map* map, char* key) {
+    return (ds3_response_header*)g_hash_table_lookup(map->map, key);
+}
+
+void ds3_map_free(ds3_map* map) {
+    if (map == NULL) {
+        return;
+    }
+
+    struct _ds3_map* _map;
+    _map = (struct _ds3_map*) map;
+    if (_map->map == NULL) return;
+
+    g_hash_table_destroy(_map->map);
+    g_free(map);
 }
 
 // caller frees all passed in values
@@ -316,7 +339,7 @@ static size_t _process_header_line(void* buffer, size_t size, size_t nmemb, void
     ds3_str* header_key;
     ds3_str* header_value;
     ds3_response_data* response_data = (ds3_response_data*) user_data;
-    GHashTable* headers = response_data->headers;
+    GHashTable* headers = (GHashTable*)response_data->headers;
 
     to_read = size * nmemb;
     if (to_read < 2) {
@@ -395,7 +418,7 @@ ds3_error* net_process_request(const ds3_client* client,
                                size_t (*read_handler_func)(void*, size_t, size_t, void*),
                                void* write_user_struct,
                                size_t (*write_handler_func)(void*, size_t, size_t, void*),
-                               GHashTable** return_headers) {
+                               ds3_map** return_headers) {
     struct _ds3_request* request = (struct _ds3_request*) _request;
     CURL* handle;
     CURLcode res;
@@ -427,7 +450,7 @@ ds3_error* net_process_request(const ds3_client* client,
             char* auth_header;
             char* checksum_value;
             ds3_response_data response_data;
-            GHashTable* response_headers = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, _ds3_free_response_header);
+            GHashTable* response_headers = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, ds3_free_response_header);
 
             ds3_log_message(client->log, DS3_DEBUG, "Preparing to send request");
 
@@ -583,7 +606,9 @@ ds3_error* net_process_request(const ds3_client* client,
             if (return_headers == NULL) {
                 g_hash_table_destroy(response_headers);
             } else {
-                *return_headers = response_headers;
+                struct _ds3_map* map = ds3_map_init();
+                map->map = response_headers;
+                *return_headers = (ds3_map*)map;
             }
 
             break;

--- a/src/ds3_net.c
+++ b/src/ds3_net.c
@@ -19,6 +19,8 @@
 #include "ds3.h"
 #include "ds3_net.h"
 #include "ds3_utils.h"
+#include "ds3_string_multimap.h"
+#include "ds3_string_multimap_impl.h"
 
 static void _init_curl(void) {
     static ds3_bool initialized = False;
@@ -309,6 +311,7 @@ void ds3_free_response_header(gpointer data) {
     g_free(data);
 }
 
+/*
 ds3_map* ds3_map_init() {
     struct _ds3_map* map = g_new0(struct _ds3_map, 1);
     map->map = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, ds3_free_response_header);
@@ -333,6 +336,7 @@ void ds3_map_free(ds3_map* map) {
     g_hash_table_destroy(_map->map);
     g_free(map);
 }
+*/
 
 static size_t _process_header_line(void* buffer, size_t size, size_t nmemb, void* user_data) {
     size_t to_read;
@@ -420,7 +424,7 @@ ds3_error* net_process_request(const ds3_client* client,
                                size_t (*read_handler_func)(void*, size_t, size_t, void*),
                                void* write_user_struct,
                                size_t (*write_handler_func)(void*, size_t, size_t, void*),
-                               ds3_map** return_headers) {
+                               ds3_string_multimap** return_headers) {
     struct _ds3_request* request = (struct _ds3_request*) _request;
     CURL* handle;
     CURLcode res;
@@ -602,15 +606,15 @@ ds3_error* net_process_request(const ds3_client* client,
                 g_free(url);
                 return error;
             }
-
             g_byte_array_free(response_data.body, TRUE);
+
             ds3_str_free(response_data.status_message);
             if (return_headers == NULL) {
                 g_hash_table_destroy(response_headers);
             } else {
-                struct _ds3_map* map = ds3_map_init();
-                map->map = response_headers;
-                *return_headers = (ds3_map*)map;
+                ds3_string_multimap* map = ds3_string_multimap_init();
+                ds3_string_multimap_set_hashtable(map, response_headers);
+                *return_headers = (ds3_string_multimap*)map;
             }
 
             break;

--- a/src/ds3_net.c
+++ b/src/ds3_net.c
@@ -285,6 +285,18 @@ static ds3_response_header* _ds3_init_response_header(const ds3_str* key) {
     return header;
 }
 
+// caller frees all passed in values
+static void _insert_header(GHashTable* headers, const ds3_str* key, const ds3_str* value) {
+    ds3_response_header* header = (ds3_response_header*)g_hash_table_lookup(headers, key->value);
+
+    if (header == NULL) {
+        header = _ds3_init_response_header(key);
+        g_hash_table_insert(headers, g_strdup(key->value), header);
+    }
+
+    g_ptr_array_add(header->values, ds3_str_dup(value));
+}
+
 void ds3_free_response_header(gpointer data) {
     ds3_response_header* header;
     if (data == NULL) {
@@ -314,22 +326,12 @@ void ds3_map_free(ds3_map* map) {
 
     struct _ds3_map* _map;
     _map = (struct _ds3_map*) map;
-    if (_map->map == NULL) return;
-
+    if (_map->map == NULL) {
+        g_free(_map);
+        return;
+    }
     g_hash_table_destroy(_map->map);
     g_free(map);
-}
-
-// caller frees all passed in values
-static void _insert_header(GHashTable* headers, const ds3_str* key, const ds3_str* value) {
-    ds3_response_header* header = (ds3_response_header*)g_hash_table_lookup(headers, key->value);
-
-    if (header == NULL) {
-        header = _ds3_init_response_header(key);
-        g_hash_table_insert(headers, g_strdup(key->value), header);
-    }
-
-    g_ptr_array_add(header->values, ds3_str_dup(value));
 }
 
 static size_t _process_header_line(void* buffer, size_t size, size_t nmemb, void* user_data) {

--- a/src/ds3_net.h
+++ b/src/ds3_net.h
@@ -18,6 +18,7 @@
 
 #include <glib.h>
 #include "ds3.h"
+#include "ds3_string_multimap.h"
 
 char* escape_url(const char* url);
 char* escape_url_object_name(const char* url);
@@ -29,15 +30,15 @@ ds3_error* net_process_request(
    size_t (*read_handler_func)(void*, size_t, size_t, void*),
    void* write_user_struct,
    size_t (*write_handler_func)(void*, size_t, size_t, void*),
-   ds3_map** return_headers);
+   ds3_string_multimap** return_headers);
 
 void net_cleanup(void);
-
+/*
 ds3_map* ds3_map_init();
 
 ds3_response_header* ds3_map_lookup(ds3_map* map, char* key);
 
 void ds3_map_free(ds3_map* map);
-
+*/
 #endif
 

--- a/src/ds3_net.h
+++ b/src/ds3_net.h
@@ -16,7 +16,6 @@
 #ifndef __DS3_NET_H__
 #define __DS3_NET_H__
 
-#include <glib.h>
 #include "ds3.h"
 #include "ds3_string_multimap.h"
 

--- a/src/ds3_net.h
+++ b/src/ds3_net.h
@@ -17,24 +17,7 @@
 #define __DS3_NET_H__
 
 #include <glib.h>
-
-typedef struct {
-    ds3_str* key;
-    GPtrArray* values; // A ds3_str list of the header values
-}ds3_response_header;
-
-typedef struct {
-    // These attributes are used when processing a response header
-    uint64_t status_code;
-    ds3_str* status_message;
-    size_t header_count;
-    GHashTable* headers;
-
-    // These attributes are used when processing a response body
-    GByteArray* body; // this will only be used when getting errors
-    void* user_data;
-    size_t (*user_func)(void*, size_t, size_t, void*);
-}ds3_response_data;
+#include "ds3.h"
 
 char* escape_url(const char* url);
 char* escape_url_object_name(const char* url);
@@ -46,9 +29,15 @@ ds3_error* net_process_request(
    size_t (*read_handler_func)(void*, size_t, size_t, void*),
    void* write_user_struct,
    size_t (*write_handler_func)(void*, size_t, size_t, void*),
-   GHashTable** return_headers);
+   ds3_map** return_headers);
 
 void net_cleanup(void);
+
+ds3_map* ds3_map_init();
+
+ds3_response_header* ds3_map_lookup(ds3_map* map, char* key);
+
+void ds3_map_free(ds3_map* map);
 
 #endif
 

--- a/src/ds3_net.h
+++ b/src/ds3_net.h
@@ -16,6 +16,10 @@
 #ifndef __DS3_NET_H__
 #define __DS3_NET_H__
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "ds3.h"
 #include "ds3_string_multimap.h"
 
@@ -33,5 +37,8 @@ ds3_error* net_process_request(
 
 void net_cleanup(void);
 
+#ifdef __cplusplus
+}
+#endif
 #endif
 

--- a/src/ds3_net.h
+++ b/src/ds3_net.h
@@ -33,12 +33,6 @@ ds3_error* net_process_request(
    ds3_string_multimap** return_headers);
 
 void net_cleanup(void);
-/*
-ds3_map* ds3_map_init();
 
-ds3_response_header* ds3_map_lookup(ds3_map* map, char* key);
-
-void ds3_map_free(ds3_map* map);
-*/
 #endif
 

--- a/src/ds3_request.h
+++ b/src/ds3_request.h
@@ -16,6 +16,10 @@
 #ifndef __DS3_REQUEST_H__
 #define __DS3_REQUEST_H__
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <glib.h>
 #include "ds3.h"
 
@@ -49,4 +53,7 @@ typedef struct {
 }ds3_response_data;
 
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/src/ds3_request.h
+++ b/src/ds3_request.h
@@ -34,9 +34,10 @@ struct _ds3_request{
     ds3_chunk_ordering    chunk_ordering;
 };
 
+/*
 struct _ds3_map {
     GHashTable* map;
-};
+};*/
 
 typedef struct {
     ds3_str* key;

--- a/src/ds3_request.h
+++ b/src/ds3_request.h
@@ -34,24 +34,13 @@ struct _ds3_request{
     ds3_chunk_ordering    chunk_ordering;
 };
 
-/*
-struct _ds3_map {
-    GHashTable* map;
-};*/
-
-typedef struct {
-    ds3_str* key;
-    GPtrArray* values; // A ds3_str list of the header values
-}ds3_response_header;
-
-void ds3_free_response_header(gpointer data);
-
 typedef struct {
     // These attributes are used when processing a response header
     uint64_t status_code;
     ds3_str* status_message;
     size_t header_count;
-    GHashTable* headers;
+    //GHashTable* headers;
+    ds3_string_multimap* headers;
 
     // These attributes are used when processing a response body
     GByteArray* body; // this will only be used when getting errors

--- a/src/ds3_request.h
+++ b/src/ds3_request.h
@@ -34,5 +34,29 @@ struct _ds3_request{
     ds3_chunk_ordering    chunk_ordering;
 };
 
-#endif
+struct _ds3_map {
+    GHashTable* map;
+};
 
+typedef struct {
+    ds3_str* key;
+    GPtrArray* values; // A ds3_str list of the header values
+}ds3_response_header;
+
+void ds3_free_response_header(gpointer data);
+
+typedef struct {
+    // These attributes are used when processing a response header
+    uint64_t status_code;
+    ds3_str* status_message;
+    size_t header_count;
+    GHashTable* headers;
+
+    // These attributes are used when processing a response body
+    GByteArray* body; // this will only be used when getting errors
+    void* user_data;
+    size_t (*user_func)(void*, size_t, size_t, void*);
+}ds3_response_data;
+
+
+#endif

--- a/src/ds3_string.c
+++ b/src/ds3_string.c
@@ -1,0 +1,56 @@
+
+/*
+* ******************************************************************************
+*   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+*   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+*   this file except in compliance with the License. A copy of the License is located at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+*   or in the "license" file accompanying this file.
+*   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+*   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+*   specific language governing permissions and limitations under the License.
+* ****************************************************************************
+*/
+
+#include "ds3_string.h"
+#include <glib.h>
+#include <string.h>
+
+ds3_str* ds3_str_init(const char* string) {
+    size_t size = strlen(string);
+    return ds3_str_init_with_size(string, size);
+}
+
+ds3_str* ds3_str_init_with_size(const char* string, size_t size) {
+    ds3_str* str = g_new0(ds3_str, 1);
+    str->value = g_strndup(string, size);
+    str->size = size;
+    return str;
+}
+
+ds3_str* ds3_str_dup(const ds3_str* string) {
+    ds3_str* str = g_new0(ds3_str, 1);
+    str->value = g_strndup(string->value, string->size);
+    str->size = string->size;
+    return str;
+}
+
+char* ds3_str_value(const ds3_str* string) {
+    return string->value;
+}
+
+size_t ds3_str_size(const ds3_str* string) {
+    return string->size;
+}
+
+void ds3_str_free(ds3_str* string) {
+    if (string == NULL) return;
+
+    if (string->value != NULL) {
+        g_free(string->value);
+    }
+    g_free(string);
+}
+

--- a/src/ds3_string.h
+++ b/src/ds3_string.h
@@ -16,6 +16,8 @@
 #ifndef __DS3_STRING__
 #define __DS3_STRING__
 
+#include <stdlib.h>
+
 typedef struct{
     char* value;
     size_t size;

--- a/src/ds3_string.h
+++ b/src/ds3_string.h
@@ -18,9 +18,31 @@
 
 #include <stdlib.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// For windows DLL symbol exports.
+#ifdef _WIN32
+#    ifdef LIBRARY_EXPORTS
+#        define LIBRARY_API __declspec(dllexport)
+#    else
+#        define LIBRARY_API __declspec(dllimport)
+#    endif
+#else
+#    define LIBRARY_API
+#endif
+
 typedef struct{
     char* value;
     size_t size;
 }ds3_str;
+
+LIBRARY_API ds3_str* ds3_str_init(const char* string);
+LIBRARY_API ds3_str* ds3_str_init_with_size(const char* string, size_t size);
+LIBRARY_API char* ds3_str_value(const ds3_str* string);
+LIBRARY_API size_t ds3_str_size(const ds3_str* string);
+LIBRARY_API ds3_str* ds3_str_dup(const ds3_str* string);
+LIBRARY_API void ds3_str_free(ds3_str* string);
 
 #endif

--- a/src/ds3_string.h
+++ b/src/ds3_string.h
@@ -45,4 +45,7 @@ LIBRARY_API size_t ds3_str_size(const ds3_str* string);
 LIBRARY_API ds3_str* ds3_str_dup(const ds3_str* string);
 LIBRARY_API void ds3_str_free(ds3_str* string);
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/src/ds3_string.h
+++ b/src/ds3_string.h
@@ -1,0 +1,24 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+#ifndef __DS3_STRING__
+#define __DS3_STRING__
+
+typedef struct{
+    char* value;
+    size_t size;
+}ds3_str;
+
+#endif

--- a/src/ds3_string_multimap.c
+++ b/src/ds3_string_multimap.c
@@ -28,9 +28,18 @@ static void _internal_string_entry_free(gpointer data) {
     ds3_str_free((ds3_str*)data);
 }
 
+static gboolean _ds3_str_equal(gconstpointer a, gconstpointer b) {
+    if ((a == NULL) || (b == NULL)) return FALSE;
+
+    const ds3_str* _a = a;
+    const ds3_str* _b = b;
+
+    return g_strcmp0(_a->value, _b->value);
+}
+
 ds3_string_multimap* ds3_string_multimap_init(void) {
     struct _ds3_string_multimap* multimap = g_new0(struct _ds3_string_multimap, 1);
-    multimap->hash = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, _free_pointer_array);
+    multimap->hash = g_hash_table_new_full(g_str_hash, _ds3_str_equal, g_free, _free_pointer_array);
 
     return (ds3_string_multimap*) multimap;
 }
@@ -47,16 +56,16 @@ void ds3_string_multimap_insert(ds3_string_multimap* map, ds3_str* key, ds3_str*
 
 ds3_string_multimap_entry* ds3_string_multimap_lookup(ds3_string_multimap* map, ds3_str* key) {
     struct _ds3_string_multimap* _map = (struct _ds3_string_multimap*)map;
-    return g_hash_table_lookup(map->hash, key->value);
+    return g_hash_table_lookup(_map->hash, key->value);
 }
 
-void ds3_string_multimap_free(ds3_string_multimap* _map) {
-    struct _ds3_string_multimap* map;
-    if (_map == NULL) return;
-    map = (struct _ds3_string_multimap*) _map;
+void ds3_string_multimap_free(ds3_string_multimap* map) {
+    struct _ds3_string_multimap* _map;
+    if (map == NULL) return;
+    _map = (struct _ds3_string_multimap*) map;
 
-    if (map->hash != NULL) {
-        g_hash_table_destroy(map->hash);
+    if (_map->hash != NULL) {
+        g_hash_table_destroy(_map->hash);
     }
 
     g_free(map);

--- a/src/ds3_string_multimap.c
+++ b/src/ds3_string_multimap.c
@@ -71,13 +71,13 @@ void ds3_string_multimap_insert_entry(ds3_string_multimap* map, const ds3_string
 
     int index;
     int num_values = ds3_string_multimap_entry_get_num_values(entry);
+    ds3_str* key = ds3_string_multimap_entry_get_key(entry);
     for (index = 0; index < num_values; index++) {
-        ds3_str* key = ds3_string_multimap_entry_get_key(entry);
         ds3_str* value = ds3_string_multimap_entry_get_value_by_index(entry, index);
         ds3_string_multimap_insert(map, key, value);
-        ds3_str_free(key);
         ds3_str_free(value);
     }
+    ds3_str_free(key);
 }
 
 // caller frees returned ds3_string_multimap_entry

--- a/src/ds3_string_multimap.c
+++ b/src/ds3_string_multimap.c
@@ -30,6 +30,7 @@ static void _internal_str_free(gpointer data) {
     ds3_str_free((ds3_str*)data);
 }
 
+// hashify the string rather than the ds3_str* for better distribution
 static guint _ds3_str_hash(gconstpointer key) {
     if (key == NULL) return 0;
 
@@ -53,7 +54,7 @@ ds3_string_multimap* ds3_string_multimap_init(void) {
     return (ds3_string_multimap*) multimap;
 }
 
-void ds3_string_multimap_insert(ds3_string_multimap* map, ds3_str* key, ds3_str* value) {
+void ds3_string_multimap_insert(ds3_string_multimap* map, const ds3_str* key, const ds3_str* value) {
     struct _ds3_string_multimap* _map = (struct _ds3_string_multimap*) map;
     GPtrArray* entries = g_hash_table_lookup(_map->hash, key);
     if (entries == NULL) {
@@ -79,7 +80,8 @@ void ds3_string_multimap_insert_entry(ds3_string_multimap* map, const ds3_string
     }
 }
 
-ds3_string_multimap_entry* ds3_string_multimap_lookup(ds3_string_multimap* map, ds3_str* key) {
+// caller frees returned ds3_string_multimap_entry
+ds3_string_multimap_entry* ds3_string_multimap_lookup(ds3_string_multimap* map, const ds3_str* key) {
     if ((map == NULL) || (key == NULL)) return NULL;
 
     struct _ds3_string_multimap* _map = (struct _ds3_string_multimap*)map;
@@ -110,6 +112,8 @@ void ds3_string_multimap_free(ds3_string_multimap* map) {
 
 
 // The following functions manipulate ds3_string_multimap_entry
+
+// caller frees returned ds3_string_multimap_entry
 ds3_string_multimap_entry* ds3_string_multimap_entry_init(const ds3_str* key) {
     struct _ds3_string_multimap_entry* _entry = g_new0(ds3_string_multimap_entry, 1);
     _entry->key = ds3_str_dup(key);
@@ -117,14 +121,15 @@ ds3_string_multimap_entry* ds3_string_multimap_entry_init(const ds3_str* key) {
     return (ds3_string_multimap_entry*)_entry;
 }
 
-void ds3_string_multimap_entry_add_value(ds3_string_multimap_entry* entry, ds3_str* value) {
+void ds3_string_multimap_entry_add_value(ds3_string_multimap_entry* entry, const ds3_str* value) {
     if ((entry == NULL) || (value == NULL)) return;
 
     struct _ds3_string_multimap_entry* _entry = entry;
     g_ptr_array_add(_entry->values, (gpointer)ds3_str_dup(value));
 }
 
-ds3_string_multimap_entry* ds3_string_multimap_entry_dupe(const ds3_string_multimap_entry* entry) {
+// caller frees returned ds3_string_multimap_entry
+ds3_string_multimap_entry* ds3_string_multimap_entry_dup(const ds3_string_multimap_entry* entry) {
     const struct _ds3_string_multimap_entry* _entry = entry;
     ds3_string_multimap_entry* duped_entry = ds3_string_multimap_entry_init(_entry->key);
     unsigned int index;

--- a/src/ds3_string_multimap.c
+++ b/src/ds3_string_multimap.c
@@ -15,11 +15,7 @@
 
 #include <glib.h>
 #include "ds3_string_multimap.h"
-
-struct _ds3_string_multimap {
-    GHashTable* hash;
-};
-
+#include "ds3_string_multimap_impl.h"
 
 static void _free_pointer_array(gpointer pointer) {
     GPtrArray* array = (GPtrArray*) pointer;
@@ -60,3 +56,4 @@ void ds3_string_multimap_free(ds3_string_multimap* _map) {
 
     g_free(map);
 }
+

--- a/src/ds3_string_multimap.h
+++ b/src/ds3_string_multimap.h
@@ -16,8 +16,8 @@
 #ifndef __DS3_STRING_MULTIMAP__
 #define __DS3_STRING_MULTIMAP__
 
+#include "ds3_string.h"
 #include <glib.h>
-#include "ds3.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -25,7 +25,6 @@ extern "C" {
 
 typedef struct _ds3_string_multimap ds3_string_multimap;
 typedef struct _ds3_string_multimap_entry ds3_string_multimap_entry;
-
 //opertions for manipulating a hash map as a ds3_str multi map
 ds3_string_multimap* ds3_string_multimap_init(void);
 void ds3_string_multimap_insert(ds3_string_multimap* map, ds3_str* key, ds3_str* value);

--- a/src/ds3_string_multimap.h
+++ b/src/ds3_string_multimap.h
@@ -29,18 +29,19 @@ typedef struct _ds3_string_multimap_entry ds3_string_multimap_entry;
 
 //opertions for manipulating a hash map as a ds3_str multi map
 ds3_string_multimap*       ds3_string_multimap_init(void);
-void                       ds3_string_multimap_insert(ds3_string_multimap* map, ds3_str* key, ds3_str* value);
+void                       ds3_string_multimap_insert(ds3_string_multimap* map, const ds3_str* key, const ds3_str* value);
 void                       ds3_string_multimap_insert_entry(ds3_string_multimap* map, const ds3_string_multimap_entry* entry);  // caller frees all passed in values
-ds3_string_multimap_entry* ds3_string_multimap_lookup(ds3_string_multimap* map, ds3_str* key);
+ds3_string_multimap_entry* ds3_string_multimap_lookup(ds3_string_multimap* map, const ds3_str* key);
 void                       ds3_string_multimap_free(ds3_string_multimap* map);
 
 
 //opertions for manipulating a ds3_string_multi_map_entry
 ds3_string_multimap_entry* ds3_string_multimap_entry_init(const ds3_str* key);
 ds3_str*                   ds3_string_multimap_entry_get_key(const ds3_string_multimap_entry* entry);
-void                       ds3_string_multimap_entry_add_value(ds3_string_multimap_entry* entry, ds3_str* value);
+void                       ds3_string_multimap_entry_add_value(ds3_string_multimap_entry* entry, const ds3_str* value);
 unsigned int               ds3_string_multimap_entry_get_num_values(const ds3_string_multimap_entry* map_entry);
 ds3_str*                   ds3_string_multimap_entry_get_value_by_index(const ds3_string_multimap_entry* entry, int index);
+ds3_string_multimap_entry* ds3_string_multimap_entry_dup(const ds3_string_multimap_entry* entry);
 void                       ds3_string_multimap_entry_free(ds3_string_multimap_entry* entry);
 
 

--- a/src/ds3_string_multimap.h
+++ b/src/ds3_string_multimap.h
@@ -29,6 +29,8 @@ ds3_string_multimap* ds3_string_multimap_init(void);
 void ds3_string_multimap_insert(ds3_string_multimap* hashtable, char* key, char* value);
 GPtrArray* ds3_string_multimap_lookup(ds3_string_multimap* hashtable, char* key);
 void ds3_string_multimap_free(ds3_string_multimap* map);
+
+
 /*
 // TODO implement this as a future refactor
 // operations for multimaps

--- a/src/ds3_string_multimap.h
+++ b/src/ds3_string_multimap.h
@@ -17,7 +17,6 @@
 #define __DS3_STRING_MULTIMAP__
 
 #include "ds3_string.h"
-#include <glib.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/ds3_string_multimap.h
+++ b/src/ds3_string_multimap.h
@@ -17,18 +17,32 @@
 #define __DS3_STRING_MULTIMAP__
 
 #include <glib.h>
+#include "ds3.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 typedef struct _ds3_string_multimap ds3_string_multimap;
+typedef struct _ds3_string_multimap_entry ds3_string_multimap_entry;
 
-//opertions for manipulating a hash map as a string multi map
+//opertions for manipulating a hash map as a ds3_str multi map
 ds3_string_multimap* ds3_string_multimap_init(void);
-void ds3_string_multimap_insert(ds3_string_multimap* hashtable, char* key, char* value);
-GPtrArray* ds3_string_multimap_lookup(ds3_string_multimap* hashtable, char* key);
+void ds3_string_multimap_insert(ds3_string_multimap* map, ds3_str* key, ds3_str* value);
+ds3_string_multimap_entry* ds3_string_multimap_lookup(ds3_string_multimap* map, ds3_str* key);
 void ds3_string_multimap_free(ds3_string_multimap* map);
+
+
+//opertions for manipulating a ds3_str multi map entry
+ds3_string_multimap_entry* ds3_init_string_multimap_entry(const ds3_str* key);
+
+// caller frees all passed in values
+void ds3_insert_string_multimap_entry(ds3_string_multimap* map, const ds3_str* key, const ds3_str* value);
+
+ds3_str* ds3_string_multimap_entry_get_value_by_index(const ds3_string_multimap_entry* entry, int index);
+
+void ds3_free_string_multimap_entry(gpointer data);
+
 
 
 /*

--- a/src/ds3_string_multimap.h
+++ b/src/ds3_string_multimap.h
@@ -23,25 +23,25 @@
 extern "C" {
 #endif
 
-typedef struct _ds3_string_multimap ds3_string_multimap;
+typedef struct _ds3_string_multimap       ds3_string_multimap;
 typedef struct _ds3_string_multimap_entry ds3_string_multimap_entry;
+
+
 //opertions for manipulating a hash map as a ds3_str multi map
-ds3_string_multimap* ds3_string_multimap_init(void);
-void ds3_string_multimap_insert(ds3_string_multimap* map, ds3_str* key, ds3_str* value);
+ds3_string_multimap*       ds3_string_multimap_init(void);
+void                       ds3_string_multimap_insert(ds3_string_multimap* map, ds3_str* key, ds3_str* value);
+void                       ds3_string_multimap_insert_entry(ds3_string_multimap* map, const ds3_string_multimap_entry* entry);  // caller frees all passed in values
 ds3_string_multimap_entry* ds3_string_multimap_lookup(ds3_string_multimap* map, ds3_str* key);
-void ds3_string_multimap_free(ds3_string_multimap* map);
+void                       ds3_string_multimap_free(ds3_string_multimap* map);
 
 
-//opertions for manipulating a ds3_str multi map entry
-ds3_string_multimap_entry* ds3_init_string_multimap_entry(const ds3_str* key);
-
-// caller frees all passed in values
-void ds3_insert_string_multimap_entry(ds3_string_multimap* map, const ds3_str* key, const ds3_str* value);
-
-ds3_str* ds3_string_multimap_entry_get_value_by_index(const ds3_string_multimap_entry* entry, int index);
-
-void ds3_free_string_multimap_entry(gpointer data);
-
+//opertions for manipulating a ds3_string_multi_map_entry
+ds3_string_multimap_entry* ds3_string_multimap_entry_init(const ds3_str* key);
+ds3_str*                   ds3_string_multimap_entry_get_key(const ds3_string_multimap_entry* entry);
+void                       ds3_string_multimap_entry_add_value(ds3_string_multimap_entry* entry, ds3_str* value);
+unsigned int               ds3_string_multimap_entry_get_num_values(const ds3_string_multimap_entry* map_entry);
+ds3_str*                   ds3_string_multimap_entry_get_value_by_index(const ds3_string_multimap_entry* entry, int index);
+void                       ds3_string_multimap_entry_free(ds3_string_multimap_entry* entry);
 
 
 /*

--- a/src/ds3_string_multimap_impl.c
+++ b/src/ds3_string_multimap_impl.c
@@ -1,14 +1,51 @@
+/*
+* ******************************************************************************
+*   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+*   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+*   this file except in compliance with the License. A copy of the License is located at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+*   or in the "license" file accompanying this file.
+*   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+*   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+*   specific language governing permissions and limitations under the License.
+* ****************************************************************************
+*/
 
+#include <glib.h>
 #include "ds3_string_multimap.h"
 #include "ds3_string_multimap_impl.h"
 
-GHashTable* ds3_string_multimap_get_hashtable(ds3_string_multimap* mp) {
-    struct _ds3_string_multimap* _mp = mp;
+GHashTable* ds3_string_multimap_get_hashtable(const ds3_string_multimap* mp) {
+    const struct _ds3_string_multimap* _mp = mp;
     return _mp->hash;
 }
 
 void ds3_string_multimap_set_hashtable(ds3_string_multimap* mp, GHashTable* ht) {
+    if (mp != NULL) {
+        ds3_string_multimap_free(mp);
+    }
+
     struct _ds3_string_multimap* _mp = mp;
     _mp->hash = ht;
 }
 
+ds3_string_multimap* ds3_string_multimap_dupe(GHashTable* response_headers) {
+    ds3_string_multimap* map = ds3_string_multimap_init();
+    GHashTableIter iter;
+    gpointer _key, _value;
+
+    g_hash_table_iter_init(&iter, response_headers);
+    while (g_hash_table_iter_next(&iter, &_key, &_value)) {
+        struct _ds3_string_multimap_entry* _entry = (ds3_string_multimap_entry*)_value;
+        if (_value == NULL) {
+            continue;
+        }
+
+        for (int index=0; index < _entry->values->len; index++) {
+            ds3_string_multimap_insert(map, _key, ds3_string_multimap_entry_get_value_by_index(_value, index));
+        }
+    }
+    return map;
+}

--- a/src/ds3_string_multimap_impl.c
+++ b/src/ds3_string_multimap_impl.c
@@ -31,24 +31,3 @@ void ds3_string_multimap_set_hashtable(ds3_string_multimap* mp, GHashTable* ht) 
     _mp->hash = ht;
 }
 
-/*
-ds3_string_multimap* ds3_string_multimap_dupe(GHashTable* response_headers) {
-    ds3_string_multimap* map = ds3_string_multimap_init();
-    GHashTableIter iter;
-    gpointer _key, _value;
-
-    g_hash_table_iter_init(&iter, response_headers);
-    while (g_hash_table_iter_next(&iter, &_key, &_value)) {
-        int index;
-        struct _ds3_string_multimap_entry* _entry = (ds3_string_multimap_entry*)_value;
-        if (_value == NULL) {
-            continue;
-        }
-
-        for (index=0; index < _entry->values->len; index++) {
-            ds3_string_multimap_insert(map, _key, ds3_string_multimap_entry_get_value_by_index(_value, index));
-        }
-    }
-    return map;
-}*/
-

--- a/src/ds3_string_multimap_impl.c
+++ b/src/ds3_string_multimap_impl.c
@@ -1,0 +1,14 @@
+
+#include "ds3_string_multimap.h"
+#include "ds3_string_multimap_impl.h"
+
+GHashTable* ds3_string_multimap_get_hashtable(ds3_string_multimap* mp) {
+    struct _ds3_string_multimap* _mp = mp;
+    return _mp->hash;
+}
+
+void ds3_string_multimap_set_hashtable(ds3_string_multimap* mp, GHashTable* ht) {
+    struct _ds3_string_multimap* _mp = mp;
+    _mp->hash = ht;
+}
+

--- a/src/ds3_string_multimap_impl.c
+++ b/src/ds3_string_multimap_impl.c
@@ -38,14 +38,16 @@ ds3_string_multimap* ds3_string_multimap_dupe(GHashTable* response_headers) {
 
     g_hash_table_iter_init(&iter, response_headers);
     while (g_hash_table_iter_next(&iter, &_key, &_value)) {
+        int index;
         struct _ds3_string_multimap_entry* _entry = (ds3_string_multimap_entry*)_value;
         if (_value == NULL) {
             continue;
         }
 
-        for (int index=0; index < _entry->values->len; index++) {
+        for (index=0; index < _entry->values->len; index++) {
             ds3_string_multimap_insert(map, _key, ds3_string_multimap_entry_get_value_by_index(_value, index));
         }
     }
     return map;
 }
+

--- a/src/ds3_string_multimap_impl.c
+++ b/src/ds3_string_multimap_impl.c
@@ -31,6 +31,7 @@ void ds3_string_multimap_set_hashtable(ds3_string_multimap* mp, GHashTable* ht) 
     _mp->hash = ht;
 }
 
+/*
 ds3_string_multimap* ds3_string_multimap_dupe(GHashTable* response_headers) {
     ds3_string_multimap* map = ds3_string_multimap_init();
     GHashTableIter iter;
@@ -49,5 +50,5 @@ ds3_string_multimap* ds3_string_multimap_dupe(GHashTable* response_headers) {
         }
     }
     return map;
-}
+}*/
 

--- a/src/ds3_string_multimap_impl.h
+++ b/src/ds3_string_multimap_impl.h
@@ -18,15 +18,21 @@
 #define __DS3_STRING_MULTIMAP_IMPL__
 
 #include <glib.h>
-#include "ds3_string_multimap.h"
 
 struct _ds3_string_multimap {
     GHashTable* hash;
 };
 
-GHashTable* ds3_string_multimap_get_hashtable(ds3_string_multimap* mp);
+typedef struct _ds3_string_multimap_entry{
+    ds3_str*   key;
+    GPtrArray* values; // A ds3_str list of the header values
+}ds3_string_multimap_entry;
+
+GHashTable* ds3_string_multimap_get_hashtable(const ds3_string_multimap* mp);
 
 void ds3_string_multimap_set_hashtable(ds3_string_multimap* mp, GHashTable* ht);
+
+void ds3_string_multimap_dupe_response_headers_hashtable(const GHashTable* src_ht, const ds3_string_multimap* dest_map );
 
 #endif
 

--- a/src/ds3_string_multimap_impl.h
+++ b/src/ds3_string_multimap_impl.h
@@ -32,7 +32,5 @@ GHashTable* ds3_string_multimap_get_hashtable(const ds3_string_multimap* mp);
 
 void ds3_string_multimap_set_hashtable(ds3_string_multimap* mp, GHashTable* ht);
 
-//void ds3_string_multimap_dupe_response_headers_hashtable(const GHashTable* src_ht, const ds3_string_multimap* dest_map );
-
 #endif
 

--- a/src/ds3_string_multimap_impl.h
+++ b/src/ds3_string_multimap_impl.h
@@ -1,0 +1,32 @@
+/*
+* ******************************************************************************
+*   Copyright 2014-2015 Spectra Logic Corporation. All Rights Reserved.
+*   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+*   this file except in compliance with the License. A copy of the License is located at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+*   or in the "license" file accompanying this file.
+*   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+*   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+*   specific language governing permissions and limitations under the License.
+* ****************************************************************************
+*/
+
+
+#ifndef __DS3_STRING_MULTIMAP_IMPL__
+#define __DS3_STRING_MULTIMAP_IMPL__
+
+#include <glib.h>
+#include "ds3_string_multimap.h"
+
+struct _ds3_string_multimap {
+    GHashTable* hash;
+};
+
+GHashTable* ds3_string_multimap_get_hashtable(ds3_string_multimap* mp);
+
+void ds3_string_multimap_set_hashtable(ds3_string_multimap* mp, GHashTable* ht);
+
+#endif
+

--- a/src/ds3_string_multimap_impl.h
+++ b/src/ds3_string_multimap_impl.h
@@ -20,7 +20,7 @@
 #include <glib.h>
 
 struct _ds3_string_multimap {
-    GHashTable* hash;
+    GHashTable* hash; //key is ds3_str, values are a GPtrArray of ds3_str
 };
 
 typedef struct _ds3_string_multimap_entry{
@@ -32,7 +32,7 @@ GHashTable* ds3_string_multimap_get_hashtable(const ds3_string_multimap* mp);
 
 void ds3_string_multimap_set_hashtable(ds3_string_multimap* mp, GHashTable* ht);
 
-void ds3_string_multimap_dupe_response_headers_hashtable(const GHashTable* src_ht, const ds3_string_multimap* dest_map );
+//void ds3_string_multimap_dupe_response_headers_hashtable(const GHashTable* src_ht, const ds3_string_multimap* dest_map );
 
 #endif
 

--- a/src/ds3_string_multimap_impl.h
+++ b/src/ds3_string_multimap_impl.h
@@ -17,6 +17,10 @@
 #ifndef __DS3_STRING_MULTIMAP_IMPL__
 #define __DS3_STRING_MULTIMAP_IMPL__
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <glib.h>
 
 struct _ds3_string_multimap {
@@ -32,5 +36,8 @@ GHashTable* ds3_string_multimap_get_hashtable(const ds3_string_multimap* mp);
 
 void ds3_string_multimap_set_hashtable(ds3_string_multimap* mp, GHashTable* ht);
 
+#ifdef __cplusplus
+}
+#endif
 #endif
 

--- a/src/ds3_utils.h
+++ b/src/ds3_utils.h
@@ -13,6 +13,9 @@
 * ****************************************************************************
 */
 
+#ifndef __DS3_UTIL__
+#define __DS3_UTIL__
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -23,4 +26,5 @@ ds3_error*   ds3_create_error(ds3_error_code code, const char * message);
 
 #ifdef __cplusplus
 }
+#endif
 #endif

--- a/src/ds3_utils.h
+++ b/src/ds3_utils.h
@@ -13,6 +13,14 @@
 * ****************************************************************************
 */
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void         ds3_log_message(const ds3_log* log, ds3_log_lvl lvl, const char* message, ...);
 size_t       ds3_load_buffer(void* buffer, size_t size, size_t nmemb, void* user_data);
 ds3_error*   ds3_create_error(ds3_error_code code, const char * message);
+
+#ifdef __cplusplus
+}
+#endif

--- a/test/Makefile
+++ b/test/Makefile
@@ -37,7 +37,7 @@ run: test
 deps:
 	./build_local.sh
 
-test: test.o checksum.o service_tests.o bucket_tests.o job_tests.o bulk_get.o get_physical_placement.o negative_tests.o metadata_tests.o deletes_test.o search_tests.o
+test: test.o checksum.o service_tests.o bucket_tests.o job_tests.o bulk_get.o get_physical_placement.o negative_tests.o metadata_tests.o deletes_test.o search_tests.o multimap_tests.o
 	$(CPP) *.o $(CFLAGS) $(LIBS) -o test
 
 test.o: ../install/lib/pkgconfig/libds3.pc
@@ -51,7 +51,7 @@ service_tests.o:
 
 search_tests.o:
 	$(CPP) -c search_tests.cpp $(CFLAGS)
-	
+
 bucket_tests.o:
 	$(CPP) -c bucket_tests.cpp $(CFLAGS)
 
@@ -71,7 +71,7 @@ negative_tests.o:
 	$(CPP) -c negative_tests.cpp $(CFLAGS)
 
 multimap_tests.o:
-	$(CPP) -c mulitmap_tests.cpp $(CFLAGS)
+	$(CPP) -c multimap_tests.cpp $(CFLAGS)
 
 checksum.o:
 	$(CPP) -c checksum.cpp $(CFLAGS)

--- a/test/build_local_debug.sh
+++ b/test/build_local_debug.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+cd ..
+
+[ ! -f configure ] && autoreconf --install
+CFLAGS="-g -O0" ./configure --prefix=`pwd`/install
+#./configure --prefix=`pwd`/install
+make install
+
+cd test

--- a/test/multimap_tests.cpp
+++ b/test/multimap_tests.cpp
@@ -1,15 +1,29 @@
+#include "ds3.h"
+#include "ds3_string.h"
 #include "ds3_string_multimap.h"
 #include <boost/test/unit_test.hpp>
 #include <glib.h>
 
-BOOST_AUTO_TEST_CASE( basic_put ) {
+BOOST_AUTO_TEST_CASE( string_multimap_insert_and_lookup ) {
+    printf("-----Testing string_multimap insert_and_lookup-------\n");
     ds3_string_multimap* map = ds3_string_multimap_init();
+    ds3_str* key = ds3_str_init("key");
+    ds3_str* value = ds3_str_init("value");
 
-    ds3_string_multimap_insert(map, "key", "value");
+    ds3_string_multimap_insert(map, key, value);
 
-    GPtrArray* values = ds3_string_multimap_lookup(map, "key");
+    ds3_string_multimap_entry* entry = ds3_string_multimap_lookup(map, key);
 
-    BOOST_CHECK(g_ptr_array_size(values) == 1);
+    BOOST_CHECK(ds3_string_multimap_entry_get_num_values(entry) == 1);
+    ds3_str* entry_key = ds3_string_multimap_entry_get_key(entry);
+    ds3_str* entry_value = ds3_string_multimap_entry_get_value_by_index(entry, 0);
+    BOOST_CHECK_EQUAL(0, g_strcmp0(entry_key->value, key->value));
+    BOOST_CHECK_EQUAL(0, g_strcmp0(entry_value->value, value->value));
 
+    ds3_str_free(key);
+    ds3_str_free(value);
+    ds3_str_free(entry_key);
+    ds3_str_free(entry_value);
     ds3_string_multimap_free(map);
+    ds3_string_multimap_entry_free(entry);
 }

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -21,7 +21,7 @@ void test_log(const char* message, void* user_data) {
 }
 
 ds3_client* get_client_at_loglvl(ds3_log_lvl log_lvl) {
-  ds3_client* client;
+    ds3_client* client;
 
     ds3_error* error = ds3_create_client_from_env(&client);
 


### PR DESCRIPTION
==13199== LEAK SUMMARY:
==13199== definitely lost: 0 bytes in 0 blocks
==13199== indirectly lost: 0 bytes in 0 blocks
==13199== possibly lost: 0 bytes in 0 blocks
==13199== still reachable: 2,550 bytes in 16 blocks
==13199== suppressed: 0 bytes in 0 blocks
==13199== 
==13199== For counts of detected and suppressed errors, rerun with: -v
==13199== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
denverm@dm-lt:~/code/github/ds3_c_sdk/test$