### PR TITLE
fix a couple memory leaks introduced in new unit tests; add a conditi…

### DIFF
--- a/src/ds3.c
+++ b/src/ds3.c
@@ -501,9 +501,9 @@ static ds3_str* _build_path(const char* path_prefix, const char* bucket_name, co
             char* chomp_bucket = g_strndup(bucket_name, strlen(bucket_name)-1);
             escaped_bucket_name = escape_url(chomp_bucket);
             g_free(chomp_bucket);
-	} else {
-	    escaped_bucket_name = escape_url(bucket_name);
-	}
+        } else {
+            escaped_bucket_name = escape_url(bucket_name);
+        }
     }
     if (object_name != NULL) {
         escaped_object_name = escape_url_object_name(object_name);
@@ -1227,7 +1227,8 @@ ds3_error* ds3_head_object(const ds3_client* client, const ds3_request* request,
     ds3_string_multimap* return_headers;
     ds3_metadata* metadata = NULL;
 
-    if (num_chars_in_ds3_str(request->path, '/') < 2){
+    if (num_chars_in_ds3_str(request->path, '/') < 2
+       || '/' == request->path->value[request->path->size-1]) {
         return ds3_create_error(DS3_ERROR_MISSING_ARGS, "The object name parameter is required.");
     }else if(g_ascii_strncasecmp(request->path->value, "//", 2) == 0){
         return ds3_create_error(DS3_ERROR_MISSING_ARGS, "The bucket name parameter is required.");

--- a/src/ds3.c
+++ b/src/ds3.c
@@ -1227,8 +1227,8 @@ ds3_error* ds3_head_object(const ds3_client* client, const ds3_request* request,
     ds3_string_multimap* return_headers;
     ds3_metadata* metadata = NULL;
 
-    if (num_chars_in_ds3_str(request->path, '/') < 2
-       || '/' == request->path->value[request->path->size-1]) {
+    int num_slashes = num_chars_in_ds3_str(request->path, '/');
+    if (num_slashes < 2 || ((num_slashes == 2) && ('/' == request->path->value[request->path->size-1]))) {
         return ds3_create_error(DS3_ERROR_MISSING_ARGS, "The object name parameter is required.");
     }else if(g_ascii_strncasecmp(request->path->value, "//", 2) == 0){
         return ds3_create_error(DS3_ERROR_MISSING_ARGS, "The bucket name parameter is required.");

--- a/test/bucket_tests.cpp
+++ b/test/bucket_tests.cpp
@@ -46,6 +46,7 @@ BOOST_AUTO_TEST_CASE( empty_object ) {
 
     request = ds3_init_put_object_for_job("unit_test_bucket", "empty-directory/", 0, 0, NULL);
     error   = ds3_put_object(client, request, NULL, NULL);
+    ds3_free_request(request);
     handle_error(error);
 
     ds3_get_bucket_response* response;

--- a/test/bulk_get.cpp
+++ b/test/bulk_get.cpp
@@ -251,13 +251,19 @@ BOOST_AUTO_TEST_CASE( escape_urls ) {
                                               "%601234567890-=~%21@%23%24%25%5E%26%2A%28%29_%2B%5B%5D%7B%7D%7C%3B%3A%2C./%3C%3E%3F"};
 
     for(int i=0; i<5; i++) {
-        BOOST_CHECK(strcmp(escape_url_object_name(strings_to_test[i]), object_name_results[i]) == 0);
+        char* escaped_url = escape_url_object_name(strings_to_test[i]);
+        BOOST_CHECK(strcmp(escaped_url, object_name_results[i]) == 0);
+        free(escaped_url);
     }
     for(int i=0; i<5; i++) {
-        BOOST_CHECK(strcmp(escape_url_range_header(strings_to_test[i]), range_header_results[i]) == 0);
+        char* escaped_url = escape_url_range_header(strings_to_test[i]);
+        BOOST_CHECK(strcmp(escaped_url, range_header_results[i]) == 0);
+        free(escaped_url);
     }
     for(int i=0; i<5; i++) {
-        BOOST_CHECK(strcmp(escape_url_extended(strings_to_test[i], delimiters, 4), general_delimiter_results[i]) == 0);
+        char* escaped_url = escape_url_extended(strings_to_test[i], delimiters, 4);
+        BOOST_CHECK(strcmp(escaped_url, general_delimiter_results[i]) == 0);
+        free(escaped_url);
     }
 }
 

--- a/test/metadata_tests.cpp
+++ b/test/metadata_tests.cpp
@@ -87,6 +87,7 @@ BOOST_AUTO_TEST_CASE( head_bucket ) {
 
 BOOST_AUTO_TEST_CASE( head_folder ) {
     printf("-----Testing head_folder-------\n");
+    ds3_metadata* metadata_result;
     ds3_error* error;
     ds3_client* client = get_client();
     const char* bucket_name = "head_folder_test";
@@ -101,10 +102,14 @@ BOOST_AUTO_TEST_CASE( head_folder ) {
     ds3_free_request(request);
     handle_error(error);
 
-    request = ds3_init_head_bucket(bucket_name);
-    error = ds3_head_bucket(client, request);
+    request = ds3_init_head_object(bucket_name, test_folder);
+
+    error = ds3_head_object(client, request, &metadata_result);
     ds3_free_request(request);
     handle_error(error);
+    BOOST_REQUIRE(metadata_result != NULL);
+    ds3_free_metadata(metadata_result);
+
     clear_bucket(client, bucket_name);
     free_client(client);
 }

--- a/test/metadata_tests.cpp
+++ b/test/metadata_tests.cpp
@@ -66,6 +66,7 @@ BOOST_AUTO_TEST_CASE( put_metadata ) {
 }
 
 BOOST_AUTO_TEST_CASE( head_bucket ) {
+    printf("-----Testing head_bucket-------\n");
     ds3_error* error;
     ds3_client* client = get_client();
     const char* bucket_name = "metadata_test";
@@ -77,6 +78,30 @@ BOOST_AUTO_TEST_CASE( head_bucket ) {
 
     request = ds3_init_head_bucket(bucket_name);
 
+    error = ds3_head_bucket(client, request);
+    ds3_free_request(request);
+    handle_error(error);
+    clear_bucket(client, bucket_name);
+    free_client(client);
+}
+
+BOOST_AUTO_TEST_CASE( head_folder ) {
+    printf("-----Testing head_folder-------\n");
+    ds3_error* error;
+    ds3_client* client = get_client();
+    const char* bucket_name = "head_folder_test";
+    ds3_request* request = ds3_init_put_bucket(bucket_name);
+    error = ds3_put_bucket(client, request);
+    ds3_free_request(request);
+    handle_error(error);
+
+    const char* test_folder = "test_folder/";
+    request = ds3_init_put_object_for_job(bucket_name, test_folder, 0, 0, NULL);
+    error   = ds3_put_object(client, request, NULL, NULL);
+    ds3_free_request(request);
+    handle_error(error);
+
+    request = ds3_init_head_bucket(bucket_name);
     error = ds3_head_bucket(client, request);
     ds3_free_request(request);
     handle_error(error);


### PR DESCRIPTION
…on to ds3_head_object to return an error before attempting the request if the object parameter is not given

==16431== LEAK SUMMARY:
==16431==    definitely lost: 0 bytes in 0 blocks
==16431==    indirectly lost: 0 bytes in 0 blocks
==16431==      possibly lost: 0 bytes in 0 blocks
==16431==    still reachable: 2,550 bytes in 16 blocks
==16431==         suppressed: 0 bytes in 0 blocks
==16431== 
==16431== For counts of detected and suppressed errors, rerun with: -v
==16431== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
denverm@dm-lt:~/code/github/ds3_c_sdk/test$ 
