### PR TITLE
refactor get_service for simpler example of response parsing in autogen

### DIFF
--- a/src/ds3.h
+++ b/src/ds3.h
@@ -212,9 +212,9 @@ typedef struct {
 }ds3_search_object;
 
 typedef struct {
-    ds3_bucket* buckets;
-    size_t      num_buckets;
-    ds3_owner*  owner;
+    ds3_bucket** buckets;
+    size_t       num_buckets;
+    ds3_owner*   owner;
 }ds3_get_service_response;
 
 typedef struct {

--- a/test/negative_tests.cpp
+++ b/test/negative_tests.cpp
@@ -39,7 +39,7 @@ BOOST_AUTO_TEST_CASE(put_duplicate_bucket) {
     handle_error(error);
 
     for (i = 0; i < response->num_buckets; i++) {
-        if (strcmp(bucket_name, response->buckets[i].name->value) == 0) {
+        if (strcmp(bucket_name, response->buckets[i]->name->value) == 0) {
             found = true;
             break;
         }
@@ -209,7 +209,7 @@ BOOST_AUTO_TEST_CASE(delete_non_existing_object) {
     handle_error(error);
 
     for (i = 0; i < response->num_buckets; i++) {
-        if (strcmp(bucket_name, response->buckets[i].name->value) == 0) {
+        if (strcmp(bucket_name, response->buckets[i]->name->value) == 0) {
             found = true;
             break;
         }

--- a/test/service_tests.cpp
+++ b/test/service_tests.cpp
@@ -42,8 +42,8 @@ BOOST_AUTO_TEST_CASE( put_bucket) {
     BOOST_CHECK(error == NULL);
 
     for (i = 0; i < response->num_buckets; i++) {
-        fprintf(stderr, "Expected Name (%s) actual (%s)\n", bucket_name, response->buckets[i].name->value);
-        if (strcmp(bucket_name, response->buckets[i].name->value) == 0) {
+        fprintf(stderr, "Expected Name (%s) actual (%s)\n", bucket_name, response->buckets[i]->name->value);
+        if (strcmp(bucket_name, response->buckets[i]->name->value) == 0) {
             found = true;
             break;
         }


### PR DESCRIPTION
*** No errors detected
==29410== 
==29410== HEAP SUMMARY:
==29410==     in use at exit: 2,550 bytes in 16 blocks
==29410==   total heap usage: 240,346 allocs, 240,330 frees, 180,453,895 bytes allocated
.
.
.
==29410== LEAK SUMMARY:
==29410==    definitely lost: 0 bytes in 0 blocks
==29410==    indirectly lost: 0 bytes in 0 blocks
==29410==      possibly lost: 0 bytes in 0 blocks
==29410==    still reachable: 2,550 bytes in 16 blocks
==29410==         suppressed: 0 bytes in 0 blocks
==29410== 
==29410== For counts of detected and suppressed errors, rerun with: -v
==29410== ERROR SUMMARY: 706 errors from 114 contexts (suppressed: 0 from 0)
