### PR TITLE
revert change involving ds3_get_service_response which broke existing…

### DIFF
--- a/src/ds3.c
+++ b/src/ds3.c
@@ -899,15 +899,16 @@ ds3_error* ds3_verify_system_health(const ds3_client* client, const ds3_request*
     return NULL;
 }
 
-static ds3_bucket* _parse_bucket( const ds3_log* log, xmlDocPtr doc, xmlNodePtr root) {
+static ds3_bucket _parse_bucket( const ds3_log* log, xmlDocPtr doc, xmlNodePtr root) {
     xmlNodePtr child_node;
-    ds3_bucket* bucket = g_new0(ds3_bucket, 1);
+    ds3_bucket bucket;
+    memset(&bucket, 0, sizeof(ds3_bucket));
 
     for (child_node = root->xmlChildrenNode; child_node != NULL; child_node = child_node->next) {
         if (element_equal(child_node, "CreationDate")) {
-            bucket->creation_date = xml_get_string(doc, child_node);
+            bucket.creation_date = xml_get_string(doc, child_node);
         } else if (element_equal(child_node, "Name")) {
-            bucket->name = xml_get_string(doc, child_node);
+            bucket.name = xml_get_string(doc, child_node);
         } else {
             ds3_log_message(log, DS3_ERROR, "Unknown element: (%s)\n", child_node->name);
         }
@@ -916,12 +917,13 @@ static ds3_bucket* _parse_bucket( const ds3_log* log, xmlDocPtr doc, xmlNodePtr 
     return bucket;
 }
 
-static GPtrArray* _parse_buckets(const ds3_log* log, xmlDocPtr doc, xmlNodePtr root) {
+static GArray* _parse_buckets(const ds3_log* log, xmlDocPtr doc, xmlNodePtr root) {
     xmlNodePtr child_node;
-    GPtrArray* buckets_array = g_ptr_array_new();
+    GArray* buckets_array = g_array_new(FALSE, TRUE, sizeof(ds3_bucket));
 
     for (child_node = root->xmlChildrenNode; child_node != NULL; child_node = child_node->next) {
-        g_ptr_array_add(buckets_array, _parse_bucket(log, doc, child_node));
+        ds3_bucket bucket = _parse_bucket(log, doc, child_node);
+        g_array_append_val(buckets_array, bucket);
     }
 
     return buckets_array;
@@ -950,10 +952,10 @@ static ds3_get_service_response* _parse_get_service_response(const ds3_log* log,
 
     for (child_node = root->xmlChildrenNode; child_node != NULL; child_node = child_node->next) {
         if (element_equal(child_node, "Buckets") == true) {
-            GPtrArray* buckets_array = _parse_buckets(log, doc, child_node);
-            response->buckets = (ds3_bucket**)buckets_array->pdata;
+            GArray* buckets_array = _parse_buckets(log, doc, child_node);
+            response->buckets = (ds3_bucket*)buckets_array->data;
             response->num_buckets = buckets_array->len;
-            g_ptr_array_free(buckets_array, FALSE);
+            g_array_free(buckets_array, FALSE);
         } else if (element_equal(child_node, "Owner") == true) {
             response->owner = _parse_owner(log, doc, child_node);
         } else {
@@ -2257,10 +2259,9 @@ void ds3_free_service_response(ds3_get_service_response* response) {
     num_buckets = response->num_buckets;
 
     for (bucket_index = 0; bucket_index < num_buckets; bucket_index++) {
-        ds3_bucket* bucket = response->buckets[bucket_index];
-        ds3_str_free(bucket->name);
-        ds3_str_free(bucket->creation_date);
-        g_free(bucket);
+        ds3_bucket bucket = response->buckets[bucket_index];
+        ds3_str_free(bucket.name);
+        ds3_str_free(bucket.creation_date);
     }
 
     ds3_free_owner(response->owner);

--- a/src/ds3.c
+++ b/src/ds3.c
@@ -899,7 +899,7 @@ ds3_error* ds3_verify_system_health(const ds3_client* client, const ds3_request*
     return NULL;
 }
 
-static ds3_bucket _parse_bucket( const ds3_log* log, xmlDocPtr doc, xmlNodePtr root) {
+static ds3_bucket _parse_bucket(const ds3_log* log, xmlDocPtr doc, xmlNodePtr root) {
     xmlNodePtr child_node;
     ds3_bucket bucket;
     memset(&bucket, 0, sizeof(ds3_bucket));

--- a/src/ds3.h
+++ b/src/ds3.h
@@ -212,9 +212,9 @@ typedef struct {
 }ds3_search_object;
 
 typedef struct {
-    ds3_bucket** buckets;
-    size_t       num_buckets;
-    ds3_owner*   owner;
+    ds3_bucket* buckets;
+    size_t      num_buckets;
+    ds3_owner*  owner;
 }ds3_get_service_response;
 
 typedef struct {

--- a/test/negative_tests.cpp
+++ b/test/negative_tests.cpp
@@ -39,7 +39,7 @@ BOOST_AUTO_TEST_CASE(put_duplicate_bucket) {
     handle_error(error);
 
     for (i = 0; i < response->num_buckets; i++) {
-        if (strcmp(bucket_name, response->buckets[i]->name->value) == 0) {
+        if (strcmp(bucket_name, response->buckets[i].name->value) == 0) {
             found = true;
             break;
         }
@@ -209,7 +209,7 @@ BOOST_AUTO_TEST_CASE(delete_non_existing_object) {
     handle_error(error);
 
     for (i = 0; i < response->num_buckets; i++) {
-        if (strcmp(bucket_name, response->buckets[i]->name->value) == 0) {
+        if (strcmp(bucket_name, response->buckets[i].name->value) == 0) {
             found = true;
             break;
         }

--- a/test/service_tests.cpp
+++ b/test/service_tests.cpp
@@ -42,8 +42,8 @@ BOOST_AUTO_TEST_CASE( put_bucket) {
     BOOST_CHECK(error == NULL);
 
     for (i = 0; i < response->num_buckets; i++) {
-        fprintf(stderr, "Expected Name (%s) actual (%s)\n", bucket_name, response->buckets[i]->name->value);
-        if (strcmp(bucket_name, response->buckets[i]->name->value) == 0) {
+        fprintf(stderr, "Expected Name (%s) actual (%s)\n", bucket_name, response->buckets[i].name->value);
+        if (strcmp(bucket_name, response->buckets[i].name->value) == 0) {
             found = true;
             break;
         }


### PR DESCRIPTION
… clients

*** No errors detected

==2058== LEAK SUMMARY:
==2058==    definitely lost: 0 bytes in 0 blocks
==2058==    indirectly lost: 0 bytes in 0 blocks
==2058==      possibly lost: 0 bytes in 0 blocks
==2058==    still reachable: 2,550 bytes in 16 blocks
==2058==         suppressed: 0 bytes in 0 blocks
==2058== 
==2058== For counts of detected and suppressed errors, rerun with: -v
==2058== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)