### PR TITLE
added a helper function for BOOST_REQUIRE( error==NULL )

### DIFF
--- a/test/bulk_get.cpp
+++ b/test/bulk_get.cpp
@@ -155,11 +155,11 @@ BOOST_AUTO_TEST_CASE( bulk_get ) {
     ds3_free_request(request);
     ds3_free_bulk_object_list(object_list);
 
-    BOOST_REQUIRE( handle_error_and_return_is_null(error) );
+    BOOST_REQUIRE(handle_error_and_return_is_null(error));
 
     chunk_response = ensure_available_chunks(client, bulk_response->job_id);
 
-    BOOST_REQUIRE( handle_error_and_return_is_null(error) );
+    BOOST_REQUIRE(handle_error_and_return_is_null(error));
 
     checksum_result* checksum_results = (checksum_result*) calloc(num_files, sizeof(checksum_result));
     checkChunkResponse(client, num_files, chunk_response, checksum_results);
@@ -218,11 +218,11 @@ BOOST_AUTO_TEST_CASE( max_upload_size ) {
     ds3_free_request(request);
     ds3_free_bulk_object_list(object_list);
 
-    BOOST_REQUIRE( handle_error_and_return_is_null(error) );
+    BOOST_REQUIRE(handle_error_and_return_is_null(error));
 
     chunk_response = ensure_available_chunks(client, bulk_response->job_id);
 
-    BOOST_REQUIRE( handle_error_and_return_is_null(error) );
+    BOOST_REQUIRE(handle_error_and_return_is_null(error));
     
     checksum_result* checksum_results = (checksum_result*) calloc(num_files, sizeof(checksum_result));
     checkChunkResponse(client, num_files, chunk_response, checksum_results);
@@ -279,7 +279,7 @@ BOOST_AUTO_TEST_CASE( chunk_preference ) {
     ds3_free_request(request);
     ds3_free_bulk_object_list(object_list);
 
-    BOOST_REQUIRE( handle_error_and_return_is_null(error) );
+    BOOST_REQUIRE(handle_error_and_return_is_null(error));
 
     do {
         retry_get = false;
@@ -291,7 +291,7 @@ BOOST_AUTO_TEST_CASE( chunk_preference ) {
 
         ds3_free_request(request);
 
-        BOOST_REQUIRE( handle_error_and_return_is_null(error) );
+        BOOST_REQUIRE(handle_error_and_return_is_null(error));
 
         BOOST_REQUIRE(chunk_response != NULL);
 
@@ -304,7 +304,7 @@ BOOST_AUTO_TEST_CASE( chunk_preference ) {
         }
     } while(retry_get);
     
-    BOOST_REQUIRE( handle_error_and_return_is_null(error) );
+    BOOST_REQUIRE(handle_error_and_return_is_null(error));
 
     checksum_result* checksum_results = (checksum_result*) calloc(num_files, sizeof(checksum_result));
     checkChunkResponse(client, num_files, chunk_response, checksum_results);
@@ -356,11 +356,11 @@ BOOST_AUTO_TEST_CASE( partial_get ) {
     ds3_free_request(request);
     ds3_free_bulk_object_list(object_list);
 
-    BOOST_REQUIRE( handle_error_and_return_is_null(error) );
+    BOOST_REQUIRE(handle_error_and_return_is_null(error));
 
     chunk_response = ensure_available_chunks(client, bulk_response->job_id);
 
-    BOOST_REQUIRE( handle_error_and_return_is_null(error) );
+    BOOST_REQUIRE(handle_error_and_return_is_null(error));
 
     checksum_result* checksum_results = (checksum_result*) calloc(num_files, sizeof(checksum_result));
     checkChunkResponsePartials(client, num_files, chunk_response, checksum_results, 3200);

--- a/test/bulk_get.cpp
+++ b/test/bulk_get.cpp
@@ -155,11 +155,11 @@ BOOST_AUTO_TEST_CASE( bulk_get ) {
     ds3_free_request(request);
     ds3_free_bulk_object_list(object_list);
 
-    BOOST_REQUIRE(error == NULL);
+    BOOST_REQUIRE( handle_error_and_return_is_null(error) );
 
     chunk_response = ensure_available_chunks(client, bulk_response->job_id);
 
-    BOOST_REQUIRE(error == NULL);
+    BOOST_REQUIRE( handle_error_and_return_is_null(error) );
 
     checksum_result* checksum_results = (checksum_result*) calloc(num_files, sizeof(checksum_result));
     checkChunkResponse(client, num_files, chunk_response, checksum_results);
@@ -218,14 +218,11 @@ BOOST_AUTO_TEST_CASE( max_upload_size ) {
     ds3_free_request(request);
     ds3_free_bulk_object_list(object_list);
 
-    // for testing puroses
-    handle_error(error);
-
-    BOOST_REQUIRE(error == NULL);
+    BOOST_REQUIRE( handle_error_and_return_is_null(error) );
 
     chunk_response = ensure_available_chunks(client, bulk_response->job_id);
 
-    BOOST_REQUIRE(error == NULL);
+    BOOST_REQUIRE( handle_error_and_return_is_null(error) );
     
     checksum_result* checksum_results = (checksum_result*) calloc(num_files, sizeof(checksum_result));
     checkChunkResponse(client, num_files, chunk_response, checksum_results);
@@ -282,7 +279,7 @@ BOOST_AUTO_TEST_CASE( chunk_preference ) {
     ds3_free_request(request);
     ds3_free_bulk_object_list(object_list);
 
-    BOOST_REQUIRE(error == NULL);
+    BOOST_REQUIRE( handle_error_and_return_is_null(error) );
 
     do {
         retry_get = false;
@@ -293,9 +290,9 @@ BOOST_AUTO_TEST_CASE( chunk_preference ) {
         error = ds3_get_available_chunks(client, request, &chunk_response);
 
         ds3_free_request(request);
-          
-        BOOST_REQUIRE(error == NULL);
-        
+
+        BOOST_REQUIRE( handle_error_and_return_is_null(error) );
+
         BOOST_REQUIRE(chunk_response != NULL);
 
         if (chunk_response->object_list->list_size == 0) {
@@ -307,7 +304,7 @@ BOOST_AUTO_TEST_CASE( chunk_preference ) {
         }
     } while(retry_get);
     
-    BOOST_REQUIRE(error == NULL);
+    BOOST_REQUIRE( handle_error_and_return_is_null(error) );
 
     checksum_result* checksum_results = (checksum_result*) calloc(num_files, sizeof(checksum_result));
     checkChunkResponse(client, num_files, chunk_response, checksum_results);
@@ -359,11 +356,11 @@ BOOST_AUTO_TEST_CASE( partial_get ) {
     ds3_free_request(request);
     ds3_free_bulk_object_list(object_list);
 
-    BOOST_REQUIRE(error == NULL);
+    BOOST_REQUIRE( handle_error_and_return_is_null(error) );
 
     chunk_response = ensure_available_chunks(client, bulk_response->job_id);
 
-    BOOST_REQUIRE(error == NULL);
+    BOOST_REQUIRE( handle_error_and_return_is_null(error) );
 
     checksum_result* checksum_results = (checksum_result*) calloc(num_files, sizeof(checksum_result));
     checkChunkResponsePartials(client, num_files, chunk_response, checksum_results, 3200);

--- a/test/job_tests.cpp
+++ b/test/job_tests.cpp
@@ -24,7 +24,7 @@ BOOST_AUTO_TEST_CASE(get_job){
 
     ds3_free_request(request);
 
-    BOOST_REQUIRE( handle_error_and_return_is_null(error) );
+    BOOST_REQUIRE(handle_error_and_return_is_null(error));
 
     object_list = ds3_convert_object_list(response->objects, response->num_objects);
 

--- a/test/job_tests.cpp
+++ b/test/job_tests.cpp
@@ -24,7 +24,7 @@ BOOST_AUTO_TEST_CASE(get_job){
 
     ds3_free_request(request);
 
-    BOOST_REQUIRE(error == NULL);
+    BOOST_REQUIRE( handle_error_and_return_is_null(error) );
 
     object_list = ds3_convert_object_list(response->objects, response->num_objects);
 

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -153,7 +153,7 @@ ds3_get_available_chunks_response* ensure_available_chunks(const ds3_client* cli
         error = ds3_get_available_chunks(client, request, &chunk_response);
         ds3_free_request(request);
 
-        BOOST_REQUIRE( handle_error_and_return_is_null(error) );
+        BOOST_REQUIRE(handle_error_and_return_is_null(error));
         BOOST_REQUIRE(chunk_response != NULL);
 
         if (chunk_response->object_list->list_size == 0) {

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -59,6 +59,12 @@ void handle_error(ds3_error* error) {
     }
 }
 
+bool handle_error_and_return_is_null(ds3_error* error){
+    bool result = (error == NULL);
+    handle_error(error);
+    return result;
+}
+
 void clear_bucket(const ds3_client* client, const char* bucket_name) {
     uint64_t i;
     ds3_request* request;
@@ -146,8 +152,8 @@ ds3_get_available_chunks_response* ensure_available_chunks(const ds3_client* cli
         request = ds3_init_get_available_chunks(job_id->value);
         error = ds3_get_available_chunks(client, request, &chunk_response);
         ds3_free_request(request);
-          
-        BOOST_REQUIRE(error == NULL);        
+
+        BOOST_REQUIRE( handle_error_and_return_is_null(error) );
         BOOST_REQUIRE(chunk_response != NULL);
 
         if (chunk_response->object_list->list_size == 0) {

--- a/test/test.h
+++ b/test/test.h
@@ -17,6 +17,7 @@ ds3_get_available_chunks_response* ensure_available_chunks(const ds3_client* cli
 
 bool contains_object(const ds3_object* objects, uint64_t num_objects, const char* obj);
 void handle_error(ds3_error* error);
+bool handle_error_and_return_is_null(ds3_error* error);
 void free_client(ds3_client* client);
 
 ds3_bulk_object_list* default_object_list();


### PR DESCRIPTION
None of the places we have BOOST_REQUIRE checking for errors currently display the error if it exists. This fixes that.