### PR TITLE
refactor ds3_get_service() to work through _parser issues for ds3_aut…

### DIFF
--- a/src/ds3.c
+++ b/src/ds3.c
@@ -916,7 +916,7 @@ ds3_error* ds3_verify_system_health(const ds3_client* client, const ds3_request*
     return NULL;
 }
 
-static ds3_error* _parse_bucket( const ds3_log* log, const xmlDocPtr doc, const xmlNodePtr root, ds3_bucket** _response) {
+static ds3_error* _parse_bucket(const ds3_log* log, const xmlDocPtr doc, const xmlNodePtr root, ds3_bucket** _response) {
     xmlNodePtr child_node;
     ds3_bucket* bucket = g_new0(ds3_bucket, 1);
 

--- a/src/ds3.c
+++ b/src/ds3.c
@@ -994,11 +994,19 @@ static ds3_error* _parse_get_service_response(const ds3_client* client, const ds
         } else {
             ds3_log_message(client->log, DS3_ERROR, "Unknown xml element: (%s)\b", child_node->name);
         }
+
+        if (error != NULL) {
+            break;
+        }
     }
 
     xmlFreeDoc(doc);
 
-    *_response = response;
+    if (error == NULL) {
+        *_response = response;
+    } else {
+        ds3_free_service_response(response);
+    }
 
     return error;
 }

--- a/src/ds3.h
+++ b/src/ds3.h
@@ -212,9 +212,9 @@ typedef struct {
 }ds3_search_object;
 
 typedef struct {
-    ds3_bucket* buckets;
-    size_t      num_buckets;
-    ds3_owner*  owner;
+    ds3_bucket** buckets;
+    size_t       num_buckets;
+    ds3_owner*   owner;
 }ds3_get_service_response;
 
 typedef struct {

--- a/test/negative_tests.cpp
+++ b/test/negative_tests.cpp
@@ -23,7 +23,7 @@
 BOOST_AUTO_TEST_CASE(put_duplicate_bucket) {
     printf("-----Negative Testing Duplicate Bucket Creation-------\n");
     ds3_client* client = get_client();
-    uint64_t i;
+    size_t i;
     bool found = false;
     const char* bucket_name = "duplicatename_test_bucket";
     ds3_request* request = ds3_init_put_bucket(bucket_name);
@@ -39,7 +39,8 @@ BOOST_AUTO_TEST_CASE(put_duplicate_bucket) {
     handle_error(error);
 
     for (i = 0; i < response->num_buckets; i++) {
-        if (strcmp(bucket_name, response->buckets[i].name->value) == 0) {
+        ds3_bucket* currentBucket = response->buckets[i];
+        if (strcmp(bucket_name, currentBucket->name->value) == 0) {
             found = true;
             break;
         }
@@ -71,8 +72,8 @@ BOOST_AUTO_TEST_CASE(put_duplicate_bucket) {
 BOOST_AUTO_TEST_CASE(delete_non_existing_bucket){
     printf("-----Negative Testing Non Existing Bucket Deletion-------\n");
     ds3_client* client = get_client();
-    ds3_request* request ;
-    ds3_error* error ;
+    ds3_request* request;
+    ds3_error* error;
     const char* bucket_name = "delete_non_existing_bucket";
     request = ds3_init_delete_bucket(bucket_name);
     error = ds3_delete_bucket(client, request);
@@ -209,7 +210,7 @@ BOOST_AUTO_TEST_CASE(delete_non_existing_object) {
     handle_error(error);
 
     for (i = 0; i < response->num_buckets; i++) {
-        if (strcmp(bucket_name, response->buckets[i].name->value) == 0) {
+        if (strcmp(bucket_name, response->buckets[i]->name->value) == 0) {
             found = true;
             break;
         }

--- a/test/service_tests.cpp
+++ b/test/service_tests.cpp
@@ -42,8 +42,8 @@ BOOST_AUTO_TEST_CASE( put_bucket) {
     BOOST_CHECK(error == NULL);
 
     for (i = 0; i < response->num_buckets; i++) {
-        fprintf(stderr, "Expected Name (%s) actual (%s)\n", bucket_name, response->buckets[i].name->value);
-        if (strcmp(bucket_name, response->buckets[i].name->value) == 0) {
+        fprintf(stderr, "Expected Name (%s) actual (%s)\n", bucket_name, response->buckets[i]->name->value);
+        if (strcmp(bucket_name, response->buckets[i]->name->value) == 0) {
             found = true;
             break;
         }

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -219,7 +219,6 @@ bool contains_object(const ds3_object* objects, uint64_t num_objects, const char
 }
 
 void free_client(ds3_client* client) {
-    ds3_free_creds(client->creds);
     ds3_free_client(client);
 }
 


### PR DESCRIPTION
…ogen::c_sdk

Also, fix warning related to unused UNSIGNED_LONG_BASE_10
*** No errors detected

==7027== LEAK SUMMARY:
==7027==    definitely lost: 0 bytes in 0 blocks
==7027==    indirectly lost: 0 bytes in 0 blocks
==7027==      possibly lost: 0 bytes in 0 blocks
==7027==    still reachable: 2,550 bytes in 16 blocks
==7027==         suppressed: 0 bytes in 0 blocks
==7027== 
==7027== For counts of detected and suppressed errors, rerun with: -v
==7027== ERROR SUMMARY: 781 errors from 16 contexts (suppressed: 0 from 0)
