### PR TITLE
update search tests to call the renamed get_objects_details_spectra_s…

### DIFF
--- a/test/search_tests.cpp
+++ b/test/search_tests.cpp
@@ -11,10 +11,10 @@ BOOST_AUTO_TEST_CASE( get_all_objects ) {
     const char* bucket_name = "search_bucket_test";
     populate_with_objects(client, bucket_name);
 
-    ds3_request* request = ds3_init_get_objects_spectra_s3_request();
+    ds3_request* request = ds3_init_get_objects_details_spectra_s3_request();
     ds3_request_set_bucket_id(request, bucket_name);
     ds3_request_set_name(request, "%txt%");
-    ds3_error* error = ds3_get_objects_spectra_s3_request(client, request, &response);
+    ds3_error* error = ds3_get_objects_details_spectra_s3_request(client, request, &response);
 
     handle_error(error);
     num_objs = response->num_s3_objects;
@@ -34,10 +34,10 @@ BOOST_AUTO_TEST_CASE( get_no_objects ) {
     const char* bucket_name = "search_bucket_test";
     populate_with_objects(client, bucket_name);
 
-    ds3_request* request = ds3_init_get_objects_spectra_s3_request();
+    ds3_request* request = ds3_init_get_objects_details_spectra_s3_request();
     ds3_request_set_bucket_id(request, bucket_name);
     ds3_request_set_name(request, "%frankenstein.txt%");
-    ds3_error* error = ds3_get_objects_spectra_s3_request(client, request, &response);
+    ds3_error* error = ds3_get_objects_details_spectra_s3_request(client, request, &response);
     handle_error(error);
     num_objs = response->num_s3_objects;
     BOOST_CHECK_EQUAL(num_objs, 0);
@@ -56,10 +56,10 @@ BOOST_AUTO_TEST_CASE( get_two_objects ) {
     const char* bucket_name = "search_bucket_test";
     populate_with_objects(client, bucket_name);
 
-    ds3_request* request = ds3_init_get_objects_spectra_s3_request();
+    ds3_request* request = ds3_init_get_objects_details_spectra_s3_request();
     ds3_request_set_bucket_id(request, bucket_name);
     ds3_request_set_name(request, "%ulysses%");
-    ds3_error* error = ds3_get_objects_spectra_s3_request(client, request, &response);
+    ds3_error* error = ds3_get_objects_details_spectra_s3_request(client, request, &response);
     handle_error(error);
     num_objs = response->num_s3_objects;
     BOOST_CHECK_EQUAL(num_objs, 2);
@@ -78,10 +78,10 @@ BOOST_AUTO_TEST_CASE( get_one_objects ) {
     const char* bucket_name = "search_bucket_test";
     populate_with_objects(client, bucket_name);
 
-    ds3_request* request = ds3_init_get_objects_spectra_s3_request();
+    ds3_request* request = ds3_init_get_objects_details_spectra_s3_request();
     ds3_request_set_bucket_id(request, bucket_name);
     ds3_request_set_name(request, "%ulysses.txt%");
-    ds3_error* error = ds3_get_objects_spectra_s3_request(client, request, &response);
+    ds3_error* error = ds3_get_objects_details_spectra_s3_request(client, request, &response);
     handle_error(error);
     num_objs = response->num_s3_objects;
     BOOST_CHECK_EQUAL(num_objs, 1);
@@ -178,10 +178,10 @@ BOOST_AUTO_TEST_CASE( get_folder_and_objects ) {
     const char* bucket_name = "search_bucket_test";
     populate_with_objects(client, bucket_name);
 
-    ds3_request* request = ds3_init_get_objects_spectra_s3_request();
+    ds3_request* request = ds3_init_get_objects_details_spectra_s3_request();
     ds3_request_set_bucket_id(request, bucket_name);
     ds3_request_set_name(request, "%resources%");
-    ds3_error* error = ds3_get_objects_spectra_s3_request(client, request, &response);
+    ds3_error* error = ds3_get_objects_details_spectra_s3_request(client, request, &response);
     handle_error(error);
     num_objs = response->num_s3_objects;
     BOOST_CHECK_EQUAL(num_objs, 5);
@@ -199,10 +199,10 @@ BOOST_AUTO_TEST_CASE( get_incorrect_bucket_name ) {
     const char* bucket_name = "search_bucket_test";
     populate_with_objects(client, bucket_name);
 
-    ds3_request* request = ds3_init_get_objects_spectra_s3_request();
+    ds3_request* request = ds3_init_get_objects_details_spectra_s3_request();
     ds3_request_set_bucket_id(request, "fake_bucket");
     ds3_request_set_name(request, "%resources%");
-    ds3_error* error = ds3_get_objects_spectra_s3_request(client, request, &response);
+    ds3_error* error = ds3_get_objects_details_spectra_s3_request(client, request, &response);
     BOOST_CHECK(error!=NULL);
     BOOST_CHECK(error->error->http_error_code == 400);
     BOOST_CHECK(strcmp(error->error->code->value ,"Bad Request") == 0);


### PR DESCRIPTION
…3_request()

==18999== Memcheck, a memory error detector
==18999== Copyright (C) 2002-2015, and GNU GPL'd, by Julian Seward et al.
==18999== Using Valgrind-3.11.0 and LibVEX; rerun with -h for copyright info
==18999== Command: ./test
==18999== 
Running 45 test cases...
-----Testing Bulk PUT-------
-----Testing put empty folder-------
-----Testing Prefix-------
-----Testing Delimiter-------
-----Testing Marker-------
-----Testing Max-Keys-------
-----Testing GetPhysicalPlacement -------
-----Testing Get Job-------
-----Testing Cancel Job-------
-----Testing Get Jobs-------
-----Testing put_metadata-------
creating metadata entry of: name
-----Testing head_bucket-------
-----Testing head_folder-------
-----Testing put_multiple_metadata_items-------
creating metadata entry of: name
creating metadata entry of: key
-----Testing metadata_keys-------
creating metadata entry of: name
creating metadata entry of: key
-----Testing put_metadata_using_get_object_retrieval-------
creating metadata entry of: name
-----Testing string_multimap insert_and_lookup-------
-----Negative Testing Duplicate Bucket Creation-------
-----Negative Testing Non Existing Bucket Deletion-------
-----Negative Testing get_bucket with empty bucket_name parameter-------
-----Negative Testing get_bucket with null bucket_name parameter-------
-----Negative Testing head_object with empty object_name parameter-------
-----Negative Testing head_object with null object_name parameter-------
-----Negative Testing Non Existing Head Bucket-------
-----Negative Testing Non Existing Object Deletion-------
-----Negative Testing Bad Bucket Name creation-------
-----Negative Testing get_bucket with bucket_name/ with trailing slash-------
-----Negative Testing Object List With Duplicate Objects Creation-------
-----Negative Testing Put Empty Object List-------
-----Negative Testing Multiple Delete Jobs-------
-----Negative Testing Non Existing Get Job-------
-----Testing GET service-------
-----Testing GET service after PUT bucket-------
Expected Name (test_put_bucket) actual (AVID_AM_DB_BACKUP)
Expected Name (test_put_bucket) actual (AVID_WG_DB_BACKUP)
Expected Name (test_put_bucket) actual (Spectra-BlackPearl-Backup-sm25-2-NO_SAS_TOPOLOGY_SERIAL)
Expected Name (test_put_bucket) actual (avid)
Expected Name (test_put_bucket) actual (test_put_bucket)
-----Testing GET system_information-------
-----Testing VerifySystemHealth-------

*** No errors detected
==18999== LEAK SUMMARY:
==18999==    definitely lost: 0 bytes in 0 blocks
==18999==    indirectly lost: 0 bytes in 0 blocks
==18999==      possibly lost: 0 bytes in 0 blocks
==18999==    still reachable: 91,646 bytes in 17 blocks
==18999==         suppressed: 0 bytes in 0 blocks
==18999== 
==18999== For counts of detected and suppressed errors, rerun with: -v
==18999== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)


