### PR TITLE
Ignore metadata entries that are NULL or empty

### DIFF
--- a/src/ds3.c
+++ b/src/ds3.c
@@ -799,11 +799,16 @@ void ds3_metadata_free(ds3_metadata* _metadata) {
 }
 
 void ds3_metadata_entry_free(ds3_metadata_entry* entry) {
+    if (entry == NULL) {
+        return;
+    }
+
     int value_index;
     ds3_str* value;
     if (entry->name != NULL) {
         ds3_str_free(entry->name);
     }
+
     if (entry->values != NULL) {
         for (value_index = 0; value_index < entry->num_values; value_index++) {
             value = entry->values[value_index];
@@ -1016,6 +1021,12 @@ void ds3_request_set_custom_header(ds3_request* _request, const char* header_nam
 }
 
 void ds3_request_set_metadata(ds3_request* _request, const char* name, const char* value) {
+    if ((value == NULL)
+      ||(strlen(value) == 0)) {
+        fprintf(stderr, "Ignoring NULL or empty entry for key %s\n", name);
+        return;
+    }
+
     char* prefixed_name = g_strconcat("x-amz-meta-", name, NULL);
 
     _set_header(_request, prefixed_name, value);

--- a/src/ds3.c
+++ b/src/ds3.c
@@ -1023,7 +1023,7 @@ void ds3_request_set_custom_header(ds3_request* _request, const char* header_nam
 void ds3_request_set_metadata(ds3_request* _request, const char* name, const char* value) {
     if ((value == NULL)
       ||(strlen(value) == 0)) {
-        fprintf(stderr, "Ignoring NULL or empty entry for key %s\n", name);
+        fprintf(stderr, "Ignoring metadata key \"%s\" which has a NULL or empty value.\n", name);
         return;
     }
 

--- a/test/metadata_tests.cpp
+++ b/test/metadata_tests.cpp
@@ -67,6 +67,125 @@ BOOST_AUTO_TEST_CASE( put_metadata ) {
     free_client(client);
 }
 
+BOOST_AUTO_TEST_CASE( put_emtpy_metadata ) {
+    printf("-----Testing put_emtpy_metadata-------\n");
+
+    ds3_bulk_object_list_response* obj_list;
+    uint64_t metadata_count;
+    ds3_master_object_list_response* bulk_response;
+    ds3_metadata* metadata_result;
+    ds3_metadata_entry* metadata_entry;
+    const char* file_name[1] = {"resources/beowulf.txt"};
+    ds3_client* client = get_client();
+    const char* bucket_name = "metadata_test";
+    FILE* file;
+
+    ds3_error* error = create_bucket_with_data_policy(client, bucket_name, ids.data_policy_id->value);
+    handle_error(error);
+
+    ds3_request* request = ds3_init_put_object_request(bucket_name, "empty-folder/", 0);
+    error = ds3_put_object_request(client, request, NULL, NULL);
+    ds3_request_free(request);
+    handle_error(error);
+
+    obj_list = ds3_convert_file_list(file_name, 1);
+
+    request = ds3_init_put_bulk_job_spectra_s3_request(bucket_name, obj_list);
+    error = ds3_put_bulk_job_spectra_s3_request(client, request, &bulk_response);
+    ds3_request_free(request);
+
+    handle_error(error);
+
+    request = ds3_init_put_object_request(bucket_name, "resources/beowulf.txt", obj_list->objects[0]->length);
+    ds3_request_set_job(request, bulk_response->job_id->value);
+    file = fopen(obj_list->objects[0]->name->value, "r");
+    ds3_bulk_object_list_response_free(obj_list);
+
+    ds3_request_set_metadata(request, "name", "");
+
+    error = ds3_put_object_request(client, request, file, ds3_read_from_file);
+    ds3_request_free(request);
+    fclose(file);
+    handle_error(error);
+    ds3_master_object_list_response_free(bulk_response);
+
+    request = ds3_init_head_object_request(bucket_name, "resources/beowulf.txt");
+
+    error = ds3_head_object_request(client, request, &metadata_result);
+    ds3_request_free(request);
+    handle_error(error);
+
+    metadata_count = ds3_metadata_size(metadata_result);
+    BOOST_CHECK(metadata_count == 0);
+
+    metadata_entry = ds3_metadata_get_entry(metadata_result, "name");
+    BOOST_REQUIRE(metadata_entry == NULL);
+
+    ds3_metadata_entry_free(metadata_entry);
+    ds3_metadata_free(metadata_result);
+    clear_bucket(client, bucket_name);
+    free_client(client);
+}
+
+BOOST_AUTO_TEST_CASE( put_null_metadata ) {
+    printf("-----Testing put_null_metadata-------\n");
+
+    ds3_bulk_object_list_response* obj_list;
+    uint64_t metadata_count;
+    ds3_master_object_list_response* bulk_response;
+    ds3_metadata* metadata_result;
+    ds3_metadata_entry* metadata_entry;
+    const char* file_name[1] = {"resources/beowulf.txt"};
+    ds3_client* client = get_client();
+    const char* bucket_name = "metadata_test";
+    FILE* file;
+
+    ds3_error* error = create_bucket_with_data_policy(client, bucket_name, ids.data_policy_id->value);
+    handle_error(error);
+
+    ds3_request* request = ds3_init_put_object_request(bucket_name, "empty-folder/", 0);
+    error = ds3_put_object_request(client, request, NULL, NULL);
+    ds3_request_free(request);
+    handle_error(error);
+
+    obj_list = ds3_convert_file_list(file_name, 1);
+
+    request = ds3_init_put_bulk_job_spectra_s3_request(bucket_name, obj_list);
+    error = ds3_put_bulk_job_spectra_s3_request(client, request, &bulk_response);
+    ds3_request_free(request);
+
+    handle_error(error);
+
+    request = ds3_init_put_object_request(bucket_name, "resources/beowulf.txt", obj_list->objects[0]->length);
+    ds3_request_set_job(request, bulk_response->job_id->value);
+    file = fopen(obj_list->objects[0]->name->value, "r");
+    ds3_bulk_object_list_response_free(obj_list);
+
+    ds3_request_set_metadata(request, "name", NULL);
+
+    error = ds3_put_object_request(client, request, file, ds3_read_from_file);
+    ds3_request_free(request);
+    fclose(file);
+    handle_error(error);
+    ds3_master_object_list_response_free(bulk_response);
+
+    request = ds3_init_head_object_request(bucket_name, "resources/beowulf.txt");
+
+    error = ds3_head_object_request(client, request, &metadata_result);
+    ds3_request_free(request);
+    handle_error(error);
+
+    metadata_count = ds3_metadata_size(metadata_result);
+    BOOST_CHECK(metadata_count == 0);
+
+    metadata_entry = ds3_metadata_get_entry(metadata_result, "name");
+    BOOST_REQUIRE(metadata_entry == NULL);
+
+    ds3_metadata_entry_free(metadata_entry);
+    ds3_metadata_free(metadata_result);
+    clear_bucket(client, bucket_name);
+    free_client(client);
+}
 BOOST_AUTO_TEST_CASE( head_bucket ) {
     printf("-----Testing head_bucket-------\n");
 


### PR DESCRIPTION
-----Testing put_metadata-------
creating metadata entry of: name
-----Testing put_emtpy_metadata-------
Ignoring NULL or empty entry for key name
-----Testing put_null_metadata-------
Ignoring NULL or empty entry for key name
-----Testing head_bucket-------
-----Testing head_folder-------
-----Testing put_multiple_metadata_items-------
creating metadata entry of: name
creating metadata entry of: key
-----Testing metadata_keys-------
creating metadata entry of: name
creating metadata entry of: key
-----Testing put_metadata_using_get_object_retrieval-------
creating metadata entry of: name
*** No errors detected
