### PR TITLE
Fix common prefix

### DIFF
--- a/src/ds3.c
+++ b/src/ds3.c
@@ -13234,8 +13234,8 @@ static ds3_error* _parse_top_level_ds3_list_bucket_result_response(const ds3_cli
     xmlNodePtr child_node;
     ds3_list_bucket_result_response* response;
     ds3_error* error = NULL;
-    GPtrArray* objects_array = g_ptr_array_new();
     GPtrArray* common_prefixes_array = g_ptr_array_new();
+    GPtrArray* objects_array = g_ptr_array_new();
 
     error = _get_request_xml_nodes(xml_blob, &doc, &root, "ListBucketResult");
     if (error != NULL) {
@@ -13283,13 +13283,12 @@ static ds3_error* _parse_top_level_ds3_list_bucket_result_response(const ds3_cli
 
     }
 
-    response->objects = (ds3_contents_response**)objects_array->pdata;
-    response->num_objects = objects_array->len;
-    g_ptr_array_free(objects_array, FALSE);
-
     response->common_prefixes = (ds3_str**)common_prefixes_array->pdata;
     response->num_common_prefixes = common_prefixes_array->len;
     g_ptr_array_free(common_prefixes_array, FALSE);
+    response->objects = (ds3_contents_response**)objects_array->pdata;
+    response->num_objects = objects_array->len;
+    g_ptr_array_free(objects_array, FALSE);
 
     xmlFreeDoc(doc);
 
@@ -13307,6 +13306,7 @@ static ds3_error* _parse_top_level_ds3_list_multi_part_uploads_result_response(c
     xmlNodePtr child_node;
     ds3_list_multi_part_uploads_result_response* response;
     ds3_error* error = NULL;
+    GPtrArray* common_prefixes_array = g_ptr_array_new();
     GPtrArray* uploads_array = g_ptr_array_new();
 
     error = _get_request_xml_nodes(xml_blob, &doc, &root, "ListMultipartUploadsResult");
@@ -13321,15 +13321,11 @@ static ds3_error* _parse_top_level_ds3_list_multi_part_uploads_result_response(c
             response->bucket = xml_get_string(doc, child_node);
         } else if (element_equal(child_node, "CommonPrefixes")) {
             xmlNodePtr loop_node;
-            GPtrArray* common_prefixes_array = g_ptr_array_new();
             int num_nodes = 0;
             for (loop_node = child_node->xmlChildrenNode; loop_node != NULL; loop_node = loop_node->next, num_nodes++) {
                 ds3_str* common_prefixes = xml_get_string(doc, loop_node);
                 g_ptr_array_add(common_prefixes_array, common_prefixes);
             }
-            response->common_prefixes = (ds3_str**)common_prefixes_array->pdata;
-            response->num_common_prefixes = common_prefixes_array->len;
-            g_ptr_array_free(common_prefixes_array, FALSE);
         } else if (element_equal(child_node, "Delimiter")) {
             response->delimiter = xml_get_string(doc, child_node);
         } else if (element_equal(child_node, "KeyMarker")) {
@@ -13361,6 +13357,9 @@ static ds3_error* _parse_top_level_ds3_list_multi_part_uploads_result_response(c
 
     }
 
+    response->common_prefixes = (ds3_str**)common_prefixes_array->pdata;
+    response->num_common_prefixes = common_prefixes_array->len;
+    g_ptr_array_free(common_prefixes_array, FALSE);
     response->uploads = (ds3_multi_part_upload_response**)uploads_array->pdata;
     response->num_uploads = uploads_array->len;
     g_ptr_array_free(uploads_array, FALSE);

--- a/src/ds3.c
+++ b/src/ds3.c
@@ -13235,6 +13235,7 @@ static ds3_error* _parse_top_level_ds3_list_bucket_result_response(const ds3_cli
     ds3_list_bucket_result_response* response;
     ds3_error* error = NULL;
     GPtrArray* objects_array = g_ptr_array_new();
+    GPtrArray* common_prefixes_array = g_ptr_array_new();
 
     error = _get_request_xml_nodes(xml_blob, &doc, &root, "ListBucketResult");
     if (error != NULL) {
@@ -13246,15 +13247,11 @@ static ds3_error* _parse_top_level_ds3_list_bucket_result_response(const ds3_cli
     for (child_node = root->xmlChildrenNode; child_node != NULL; child_node = child_node->next) {
         if (element_equal(child_node, "CommonPrefixes")) {
             xmlNodePtr loop_node;
-            GPtrArray* common_prefixes_array = g_ptr_array_new();
             int num_nodes = 0;
             for (loop_node = child_node->xmlChildrenNode; loop_node != NULL; loop_node = loop_node->next, num_nodes++) {
                 ds3_str* common_prefixes = xml_get_string(doc, loop_node);
                 g_ptr_array_add(common_prefixes_array, common_prefixes);
             }
-            response->common_prefixes = (ds3_str**)common_prefixes_array->pdata;
-            response->num_common_prefixes = common_prefixes_array->len;
-            g_ptr_array_free(common_prefixes_array, FALSE);
         } else if (element_equal(child_node, "CreationDate")) {
             response->creation_date = xml_get_string(doc, child_node);
         } else if (element_equal(child_node, "Delimiter")) {
@@ -13289,6 +13286,10 @@ static ds3_error* _parse_top_level_ds3_list_bucket_result_response(const ds3_cli
     response->objects = (ds3_contents_response**)objects_array->pdata;
     response->num_objects = objects_array->len;
     g_ptr_array_free(objects_array, FALSE);
+
+    response->common_prefixes = (ds3_str**)common_prefixes_array->pdata;
+    response->num_common_prefixes = common_prefixes_array->len;
+    g_ptr_array_free(common_prefixes_array, FALSE);
 
     xmlFreeDoc(doc);
 

--- a/test/bucket_tests.cpp
+++ b/test/bucket_tests.cpp
@@ -111,6 +111,44 @@ BOOST_AUTO_TEST_CASE( delimiter ) {
     free_client(client);
 }
 
+BOOST_AUTO_TEST_CASE( common_prefixes ) {
+    printf("-----Testing CommonPrefixes-------\n");
+
+    ds3_request* request;
+    ds3_error* error;
+    ds3_list_bucket_result_response* response;
+    ds3_client* client = get_client();
+    const char* bucket_name = "test_common_prefixes_bucket";
+    ds3_bool found_resources = False;
+    ds3_bool found_resources_2 = False;
+    size_t common_prefix_index;
+
+    populate_with_multi_dir_objects(client, bucket_name);
+
+    request = ds3_init_get_bucket_request(bucket_name);
+    ds3_request_set_delimiter(request, "/");
+    ds3_request_set_prefix(request, "resources");
+    error = ds3_get_bucket_request(client, request, &response);
+    ds3_request_free(request);
+    handle_error(error);
+
+    BOOST_CHECK_EQUAL(response->num_objects, 0);
+    BOOST_CHECK_EQUAL(response->num_common_prefixes, 2);
+    for(common_prefix_index = 0; common_prefix_index < response->num_common_prefixes; common_prefix_index++) {
+        if(strcmp(response->common_prefixes[common_prefix_index]->value, "resources/") == 0) {
+            found_resources = True;
+        } else if (strcmp(response->common_prefixes[common_prefix_index]->value, "resources_2/") == 0) {
+            found_resources_2 = True;
+        }
+    }
+    BOOST_CHECK_EQUAL(found_resources, True);
+    BOOST_CHECK_EQUAL(found_resources_2, True);
+
+    ds3_list_bucket_result_response_free(response);
+    clear_bucket(client, bucket_name);
+    free_client(client);
+}
+
 BOOST_AUTO_TEST_CASE(marker) {
     printf("-----Testing Marker-------\n");
 

--- a/test/resources_2/bar.txt
+++ b/test/resources_2/bar.txt
@@ -1,0 +1,1 @@
+This is bar.

--- a/test/resources_2/foo.txt
+++ b/test/resources_2/foo.txt
@@ -1,0 +1,1 @@
+This is foo.

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -201,7 +201,7 @@ void populate_with_objects(const ds3_client* client, const char* bucket_name) {
 }
 
 void populate_with_multi_dir_objects(const ds3_client* client, const char* bucket_name) {
-    ds3_str* job_id = populate_with_object_list_return_job(client, bucket_name, multi_dirs_object_list());
+    ds3_str* job_id = populate_with_multi_dir_objects_return_job(client, bucket_name);
     ds3_str_free(job_id);
 }
 
@@ -319,7 +319,17 @@ ds3_str* populate_with_object_list_return_job( const ds3_client* client,
 }
 
 ds3_str* populate_with_objects_return_job(const ds3_client* client, const char* bucket_name) {
-    return populate_with_object_list_return_job(client, bucket_name, default_object_list());
+    ds3_bulk_object_list_response* obj_list = default_object_list();
+    ds3_str* job_id = populate_with_object_list_return_job(client, bucket_name, obj_list);
+    ds3_bulk_object_list_response_free(obj_list);
+    return job_id;
+}
+
+ds3_str* populate_with_multi_dir_objects_return_job(const ds3_client* client, const char* bucket_name) {
+    ds3_bulk_object_list_response* obj_list = multi_dirs_object_list();
+    ds3_str* job_id = populate_with_object_list_return_job(client, bucket_name, obj_list);
+    ds3_bulk_object_list_response_free(obj_list);
+    return job_id;
 }
 
 bool contains_object(ds3_list_bucket_result_response* bucket_list, const char* key) {

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -200,9 +200,25 @@ void populate_with_objects(const ds3_client* client, const char* bucket_name) {
     ds3_str_free(job_id);
 }
 
+void populate_with_multi_dir_objects(const ds3_client* client, const char* bucket_name) {
+    ds3_str* job_id = populate_with_object_list_return_job(client, bucket_name, multi_dirs_object_list());
+    ds3_str_free(job_id);
+}
+
 ds3_bulk_object_list_response* default_object_list() {
     const char* books[5] = {"resources/beowulf.txt", "resources/sherlock_holmes.txt", "resources/tale_of_two_cities.txt", "resources/ulysses.txt", "resources/ulysses_large.txt"};
     return ds3_convert_file_list(books, 5);
+}
+
+ds3_bulk_object_list_response* multi_dirs_object_list() {
+    const char* books[6] = {
+      "resources/beowulf.txt",
+      "resources/sherlock_holmes.txt",
+      "resources/tale_of_two_cities.txt",
+      "resources/ulysses.txt",
+      "resources_2/foo.txt",
+      "resources_2/bar.txt"};
+    return ds3_convert_file_list(books, 6);
 }
 
 ds3_request* populate_bulk_return_request(const ds3_client* client, const char* bucket_name, ds3_bulk_object_list_response* obj_list) {
@@ -289,17 +305,21 @@ void populate_with_objects_from_bulk(const ds3_client* client, const char* bucke
     ds3_master_object_list_response_free(chunk_response);
 }
 
-ds3_str* populate_with_objects_return_job(const ds3_client* client, const char* bucket_name) {
-    ds3_bulk_object_list_response* bulk_object_list_response = default_object_list();
-    ds3_request* request = populate_bulk_return_request(client, bucket_name, bulk_object_list_response);
+ds3_str* populate_with_object_list_return_job( const ds3_client* client,
+                                               const char* bucket_name,
+                                               ds3_bulk_object_list_response* object_list) {
+    ds3_request* request = populate_bulk_return_request(client, bucket_name, object_list);
     ds3_master_object_list_response* master_object_list_response = populate_bulk_return_response(client, request);
 
     ds3_str* job_id = ds3_str_dup(master_object_list_response->job_id);
     populate_with_objects_from_bulk(client, bucket_name, master_object_list_response);
 
-    ds3_bulk_object_list_response_free(bulk_object_list_response);
     ds3_master_object_list_response_free(master_object_list_response);
     return job_id;
+}
+
+ds3_str* populate_with_objects_return_job(const ds3_client* client, const char* bucket_name) {
+    return populate_with_object_list_return_job(client, bucket_name, default_object_list());
 }
 
 bool contains_object(ds3_list_bucket_result_response* bucket_list, const char* key) {

--- a/test/test.h
+++ b/test/test.h
@@ -26,10 +26,13 @@ void clear_bucket(const ds3_client* client, const char* bucket_name);
 
 void populate_with_objects(const ds3_client* client, const char* bucket_name);
 void populate_with_multi_dir_objects(const ds3_client* client, const char* bucket_name);
+
 ds3_str* populate_with_object_list_return_job( const ds3_client* client,
                                                const char* bucket_name,
                                                ds3_bulk_object_list_response* object_list);
+
 ds3_str* populate_with_objects_return_job(const ds3_client* client, const char* bucket_name);
+ds3_str* populate_with_multi_dir_objects_return_job(const ds3_client* client, const char* bucket_name);
 ds3_str* populate_with_empty_objects(const ds3_client* client, const char* bucket_name);
 
 ds3_request* populate_bulk_return_request(const ds3_client* client, const char* bucket_name, ds3_bulk_object_list_response* obj_list);

--- a/test/test.h
+++ b/test/test.h
@@ -25,6 +25,10 @@ void teardown_after_tests();
 void clear_bucket(const ds3_client* client, const char* bucket_name);
 
 void populate_with_objects(const ds3_client* client, const char* bucket_name);
+void populate_with_multi_dir_objects(const ds3_client* client, const char* bucket_name);
+ds3_str* populate_with_object_list_return_job( const ds3_client* client,
+                                               const char* bucket_name,
+                                               ds3_bulk_object_list_response* object_list);
 ds3_str* populate_with_objects_return_job(const ds3_client* client, const char* bucket_name);
 ds3_str* populate_with_empty_objects(const ds3_client* client, const char* bucket_name);
 
@@ -41,6 +45,7 @@ void handle_error(ds3_error* error);
 void free_client(ds3_client* client);
 
 ds3_bulk_object_list_response* default_object_list();
+ds3_bulk_object_list_response* multi_dirs_object_list();
 
 ds3_error* create_bucket_with_data_policy(const ds3_client* client, const char* bucket_id, const char* data_policy_id);
 


### PR DESCRIPTION
<CommonPrefixes><Prefix>movies/</Prefix></CommonPrefixes><CommonPrefixes><Prefix>scores/</Prefix></CommonPrefixes>
Each CommonPrefixes block needs to be parsed separately

==8380== Memcheck, a memory error detector
==8380== Copyright (C) 2002-2015, and GNU GPL'd, by Julian Seward et al.
==8380== Using Valgrind-3.11.0 and LibVEX; rerun with -h for copyright info
==8380== Command: ./test
==8380== 
Running 49 test cases...
-----Testing Bulk PUT-------
-----Testing put empty folder-------
-----Testing Prefix-------
-----Testing Delimiter-------
-----Testing CommonPrefixes-------
-----Testing Marker-------
-----Testing Max-Keys-------
-----Testing GetPhysicalPlacement -------
-----Testing Get Job-------
-----Testing Cancel Job-------
-----Testing Get Jobs-------
-----Testing put_metadata-------
creating metadata entry of: name
-----Testing put_emtpy_metadata-------
Ignoring metadata key "name" which has a NULL or empty value.
-----Testing put_null_metadata-------
Ignoring metadata key "name" which has a NULL or empty value.
-----Testing head_bucket-------
-----Testing head_folder-------
-----Testing put_multiple_metadata_items-------
creating metadata entry of: name
creating metadata entry of: key
-----Testing metadata_keys-------
creating metadata entry of: name
creating metadata entry of: key
-----Testing put_metadata_using_get_object_retrieval-------
creating metadata entry of: name
-----Testing string_multimap insert_and_lookup-------
-----Negative Testing Duplicate Bucket Creation-------
-----Negative Testing Non Existing Bucket Deletion-------
-----Negative Testing get_bucket with empty bucket_name parameter-------
-----Negative Testing get_bucket with null bucket_name parameter-------
-----Negative Testing head_object with empty object_name parameter-------
-----Negative Testing head_object with null object_name parameter-------
-----Negative Testing Non Existing Head Bucket-------
-----Negative Testing Non Existing Object Deletion-------
-----Negative Testing Bad Bucket Name creation-------
-----Negative Testing get_bucket with bucket_name/ with trailing slash-------
-----Negative Testing Object List With Duplicate Objects Creation-------
-----Negative Testing Put Empty Object List-------
-----Negative Testing Multiple Delete Jobs-------
-----Negative Testing Non Existing Get Job-------
-----Testing get_objects_with_full_details-------
-----Testing GET service-------
-----Testing GET service after PUT bucket-------
Expected Name (test_put_bucket) actual (test_put_bucket)
-----Testing GET system_information-------
-----Testing VerifySystemHealth-------

*** No errors detected

==8380== LEAK SUMMARY:
==8380==    definitely lost: 0 bytes in 0 blocks
==8380==    indirectly lost: 0 bytes in 0 blocks
==8380==      possibly lost: 0 bytes in 0 blocks
==8380==    still reachable: 91,646 bytes in 17 blocks
==8380==         suppressed: 0 bytes in 0 blocks
==8380== 
==8380== For counts of detected and suppressed errors, rerun with: -v
==8380== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
