### PR TITLE
fix get_objects_request passing of user_data and callback

### DIFF
--- a/src/ds3.c
+++ b/src/ds3.c
@@ -13375,55 +13375,6 @@ static ds3_error* _parse_top_level_ds3_list_multi_part_uploads_result_response(c
     return error;
 }
 
-ds3_error* ds3_head_bucket_request(const ds3_client* client, const ds3_request* request) {
-    if (client == NULL || request == NULL) {
-        return ds3_create_error(DS3_ERROR_MISSING_ARGS, "All arguments must be filled in for request processing");
-    }
-    if (g_ascii_strncasecmp(request->path->value, "//", 2) == 0) {
-        return ds3_create_error(DS3_ERROR_MISSING_ARGS, "The bucket name parameter is required.");
-    }
-
-    return _internal_request_dispatcher(client, request, NULL, NULL, NULL, NULL, NULL);
-}
-
-ds3_error* ds3_head_object_request(const ds3_client* client, const ds3_request* request, ds3_metadata** _metadata) {
-    ds3_error* error;
-    ds3_string_multimap* return_headers;
-    ds3_metadata* metadata;
-
-    int num_slashes = num_chars_in_ds3_str(request->path, '/');
-    if (num_slashes < 2 || ((num_slashes == 2) && ('/' == request->path->value[request->path->size-1]))) {
-        return ds3_create_error(DS3_ERROR_MISSING_ARGS, "The object name parameter is required.");
-    } else if (g_ascii_strncasecmp(request->path->value, "//", 2) == 0) {
-        return ds3_create_error(DS3_ERROR_MISSING_ARGS, "The bucket name parameter is required.");
-    }
-
-    error = _internal_request_dispatcher(client, request, NULL, NULL, NULL, NULL, &return_headers);
-
-    if (error == NULL) {
-        metadata = _init_metadata(return_headers);
-        *_metadata = metadata;
-        ds3_string_multimap_free(return_headers);
-    }
-
-    return error;
-}
-
-
-ds3_error* ds3_get_object_with_metadata(const ds3_client* client, const ds3_request* request, void* user_data, size_t (* callback)(void*, size_t, size_t, void*), ds3_metadata** _metadata) {
-    ds3_error* error;
-    ds3_string_multimap* return_headers;
-    ds3_metadata* metadata;
-
-    error = _internal_request_dispatcher(client, request, user_data, callback, NULL, NULL, &return_headers);
-    if (error == NULL) {
-        metadata = _init_metadata(return_headers);
-        *_metadata = metadata;
-        ds3_string_multimap_free(return_headers);
-    }
-
-    return error;
-}
 
 ds3_error* ds3_abort_multi_part_upload_request(const ds3_client* client, const ds3_request* request) {
 
@@ -13570,7 +13521,9 @@ ds3_error* ds3_get_service_request(const ds3_client* client, const ds3_request* 
 
     return _parse_top_level_ds3_list_all_my_buckets_result_response(client, request, response, xml_blob);
 }
-ds3_error* ds3_get_object_request(const ds3_client* client, const ds3_request* request, void* user_data, size_t (*callback)(void*, size_t, size_t, void*)) {
+
+ds3_error* ds3_get_object_request(const ds3_client* client, const ds3_request* request, void* user_data, size_t (* callback)(void*, size_t, size_t, void*)) {
+    ds3_error* error;
 
     int num_slashes = num_chars_in_ds3_str(request->path, '/');
     if (num_slashes < 2 || ((num_slashes == 2) && ('/' == request->path->value[request->path->size-1]))) {
@@ -13579,8 +13532,66 @@ ds3_error* ds3_get_object_request(const ds3_client* client, const ds3_request* r
         return ds3_create_error(DS3_ERROR_MISSING_ARGS, "The object name parameter is required.");
     }
 
+    error = _internal_request_dispatcher(client, request, user_data, callback, NULL, NULL, NULL);
+
+    return error;
+}
+
+ds3_error* ds3_get_object_with_metadata(const ds3_client* client, const ds3_request* request, void* user_data, size_t (* callback)(void*, size_t, size_t, void*), ds3_metadata** _metadata) {
+    ds3_error* error;
+    ds3_string_multimap* return_headers;
+    ds3_metadata* metadata;
+
+    int num_slashes = num_chars_in_ds3_str(request->path, '/');
+    if (num_slashes < 2 || ((num_slashes == 2) && ('/' == request->path->value[request->path->size-1]))) {
+        return ds3_create_error(DS3_ERROR_MISSING_ARGS, "The bucket name parameter is required.");
+    } else if (g_ascii_strncasecmp(request->path->value, "//", 2) == 0) {
+        return ds3_create_error(DS3_ERROR_MISSING_ARGS, "The object name parameter is required.");
+    }
+
+    error = _internal_request_dispatcher(client, request, user_data, callback, NULL, NULL, &return_headers);
+    if (error == NULL) {
+        metadata = _init_metadata(return_headers);
+        *_metadata = metadata;
+        ds3_string_multimap_free(return_headers);
+    }
+
+    return error;
+}
+ds3_error* ds3_head_bucket_request(const ds3_client* client, const ds3_request* request) {
+    if (client == NULL || request == NULL) {
+        return ds3_create_error(DS3_ERROR_MISSING_ARGS, "All arguments must be filled in for request processing");
+    }
+    if (g_ascii_strncasecmp(request->path->value, "//", 2) == 0) {
+        return ds3_create_error(DS3_ERROR_MISSING_ARGS, "The bucket name parameter is required.");
+    }
+
     return _internal_request_dispatcher(client, request, NULL, NULL, NULL, NULL, NULL);
 }
+
+ds3_error* ds3_head_object_request(const ds3_client* client, const ds3_request* request, ds3_metadata** _metadata) {
+    ds3_error* error;
+    ds3_string_multimap* return_headers;
+    ds3_metadata* metadata;
+
+    int num_slashes = num_chars_in_ds3_str(request->path, '/');
+    if (num_slashes < 2 || ((num_slashes == 2) && ('/' == request->path->value[request->path->size-1]))) {
+        return ds3_create_error(DS3_ERROR_MISSING_ARGS, "The object name parameter is required.");
+    } else if (g_ascii_strncasecmp(request->path->value, "//", 2) == 0) {
+        return ds3_create_error(DS3_ERROR_MISSING_ARGS, "The bucket name parameter is required.");
+    }
+
+    error = _internal_request_dispatcher(client, request, NULL, NULL, NULL, NULL, &return_headers);
+
+    if (error == NULL) {
+        metadata = _init_metadata(return_headers);
+        *_metadata = metadata;
+        ds3_string_multimap_free(return_headers);
+    }
+
+    return error;
+}
+
 ds3_error* ds3_initiate_multi_part_upload_request(const ds3_client* client, const ds3_request* request, ds3_initiate_multipart_upload_result_response** response) {
     ds3_error* error;
     GByteArray* xml_blob;

--- a/test/Makefile
+++ b/test/Makefile
@@ -40,7 +40,7 @@ run_single: test
 deps:
 	./build_local.sh
 
-test: test.o get_physical_placement.o search_tests.o metadata_tests.o negative_tests.o checksum.o service_tests.o bucket_tests.o multimap_tests.o deletes_test.o job_tests.o # bulk_get.o
+test: test.o get_physical_placement.o search_tests.o metadata_tests.o negative_tests.o checksum.o service_tests.o bucket_tests.o multimap_tests.o deletes_test.o job_tests.o get_object.o bulk_get.o
 	$(CPP) *.o $(CFLAGS) $(LIBS) -o test
 
 test.o: ../install/lib/pkgconfig/libds3.pc
@@ -66,6 +66,9 @@ job_tests.o:
 
 bulk_get.o:
 	$(CPP) -c bulk_get.cpp $(CFLAGS)
+
+get_object.o:
+	$(CPP) -c get_object.cpp $(CFLAGS)
 
 get_physical_placement.o:
 	$(CPP) -c get_physical_placement.cpp $(CFLAGS)

--- a/test/get_object.cpp
+++ b/test/get_object.cpp
@@ -1,0 +1,69 @@
+#include <stdio.h>
+#include "ds3.h"
+#include "test.h"
+#include <boost/test/unit_test.hpp>
+#include <glib.h>
+#include <sys/stat.h>
+
+ds3_contents_response* get_contents_by_name(const ds3_list_bucket_result_response* bucket_list, const char* object_name) {
+    if (bucket_list == NULL) {
+        return NULL;
+    }
+
+    ds3_contents_response* object = NULL;
+    for (size_t object_index = 0; object_index < bucket_list->num_objects; object_index++) {
+        object = bucket_list->objects[object_index];
+        if (g_strcmp0(object_name, object->key->value) == 0) {
+            return object;
+        }
+    }
+
+    return NULL;
+}
+
+BOOST_AUTO_TEST_CASE( get_object ) {
+    printf("-----Testing GET object-------\n");
+
+    const char* bucket_name = "test_get_object_bucket";
+    const char* object_name = "resources/sherlock_holmes.txt";
+    const char* get_object_name = "sherlock_holmes_get.txt";
+    ds3_request* request = NULL;
+    ds3_error* error = NULL;
+    ds3_list_bucket_result_response* get_bucket_response;
+    ds3_contents_response* sherlock = NULL;
+    uint64_t sherlock_size = 0;
+    FILE* fp;
+    struct stat fstat;
+    int status = 0;
+
+    ds3_client* client = get_client();
+    populate_with_objects(client, bucket_name);
+
+    request = ds3_init_get_bucket_request(bucket_name);
+    error = ds3_get_bucket_request(client, request, &get_bucket_response);
+    ds3_request_free(request);
+    handle_error(error);
+
+    sherlock = get_contents_by_name(get_bucket_response, object_name);
+    BOOST_CHECK(sherlock != NULL);
+
+    sherlock_size = sherlock->size;
+    ds3_list_bucket_result_response_free(get_bucket_response);
+
+    request = ds3_init_get_object_request(bucket_name, object_name, sherlock_size);
+    fp = fopen(get_object_name, "w+");
+
+    error = ds3_get_object_request(client, request, fp, ds3_write_to_file);
+    ds3_request_free(request);
+    fclose(fp);
+    handle_error(error);
+
+    status = stat(get_object_name, &fstat);
+    BOOST_CHECK(status != -1);
+    BOOST_CHECK(fstat.st_size > 0);
+
+    remove(get_object_name);
+    clear_bucket(client, bucket_name);
+    free_client(client);
+}
+


### PR DESCRIPTION
13535 is the only really changed line - the others are just moved into the normal ordering of the API contract instead of all special cased requests being at the beginning.

+    error = _internal_request_dispatcher(client, request, user_data, callback, NULL, NULL, NULL);
