### PR TITLE
escape plus(+) char in object names; re-enable related tests

### DIFF
--- a/src/ds3_net.c
+++ b/src/ds3_net.c
@@ -91,10 +91,10 @@ char* escape_url_extended(const char* url, const char** delimiters, uint32_t num
     return escaped_ptr;
 }
 
-// Like escape_url but don't encode "/" or "+".
+// Like escape_url but don't encode "/".
 char* escape_url_object_name(const char* url) {
-    const char *delimiters[2]={"/","+"};
-    return escape_url_extended(url, delimiters, 2);
+    const char *delimiters[1]={"/"};
+    return escape_url_extended(url, delimiters, 1);
 }
 
 // Like escape_url but don't encode "=".

--- a/test/bulk_get.cpp
+++ b/test/bulk_get.cpp
@@ -278,7 +278,7 @@ BOOST_AUTO_TEST_CASE( chunk_preference ) {
     ds3_master_object_list_response* chunk_response = NULL;
     bool retry_get;
 
-    ds3_client* client = get_client_at_loglvl(DS3_TRACE);
+    ds3_client* client = get_client();
     const char* bucket_name = "test_chunk_preference_bucket";
 
     printf("-----Testing Bulk GET with chunk_preference-------\n");
@@ -405,7 +405,7 @@ BOOST_AUTO_TEST_CASE( escape_urls ) {
     const char *delimiters[4] = {"or", "/", "@", "="};
     const char *strings_to_test[5] = {"some normal text", "/an/object/name", "bytes=0-255,300-400,550-800", "orqwerty/qwerty@qwerty=", "`1234567890-=~!@#$%^&*()_+[]\{}|;:,./<>?"}; 
     const char *object_name_results[5] = {"some%20normal%20text", "/an/object/name", "bytes%3D0-255%2C300-400%2C550-800", "orqwerty/qwerty%40qwerty%3D",
-                                        "%601234567890-%3D~%21%40%23%24%25%5E%26%2A%28%29_+%5B%5D%7B%7D%7C%3B%3A%2C./%3C%3E%3F"};
+                                        "%601234567890-%3D~%21%40%23%24%25%5E%26%2A%28%29_%2B%5B%5D%7B%7D%7C%3B%3A%2C./%3C%3E%3F"};
     const char *range_header_results[5] = {"some%20normal%20text", "%2Fan%2Fobject%2Fname", "bytes=0-255,300-400,550-800", "orqwerty%2Fqwerty%40qwerty=",
                                          "%601234567890-=~%21%40%23%24%25%5E%26%2A%28%29_%2B%5B%5D%7B%7D%7C%3B%3A,.%2F%3C%3E%3F"};
     const char *general_delimiter_results[5] = {"some%20normal%20text", "/an/object/name", "bytes=0-255%2C300-400%2C550-800", "orqwerty/qwerty@qwerty=",

--- a/test/search_tests.cpp
+++ b/test/search_tests.cpp
@@ -2,6 +2,7 @@
 #include <stdio.h>
 #include "ds3.h"
 #include "test.h"
+#include <sys/stat.h>
 #include <boost/test/unit_test.hpp>
 
 BOOST_AUTO_TEST_CASE( get_all_objects ) {
@@ -118,20 +119,25 @@ BOOST_AUTO_TEST_CASE( get_one_objects ) {
     free_client(client);
 }
 
-/* Disabling from nightly test until network timeout failure is resolved */
-/*
-BOOST_AUTO_TEST_CASE(get_objects_details_with_plus_query_param) {
+BOOST_AUTO_TEST_CASE(get_objects_with_plus_query_param) {
     printf("-----Testing Search Object with +-------\n");
 
     ds3_client* client = get_client();
     const char* bucket_name = "get_objects_details_with_plus_query_param";
     const char* plus_object = "Plus+Object";
+    const char* local_file_to_put = "resources/beowulf.txt";
+    struct stat file_info;
+    memset(&file_info, 0, sizeof(struct stat));
+    uint64_t file_size = 0;
 
     ds3_error* bucket_error = create_bucket_with_data_policy(client, bucket_name, ids.data_policy_id->value);
     handle_error(bucket_error);
 
-    ds3_request* put_request = ds3_init_put_object_request(bucket_name, plus_object, 1024);
-    FILE* obj_file = fopen("resources/beowulf.txt", "r");
+    stat(local_file_to_put, &file_info);
+    file_size = file_info.st_size;
+
+    ds3_request* put_request = ds3_init_put_object_request(bucket_name, plus_object, file_size);
+    FILE* obj_file = fopen(local_file_to_put, "r");
 
     ds3_error* error = ds3_put_object_request(client, put_request, obj_file, ds3_read_from_file);
     ds3_request_free(put_request);
@@ -155,22 +161,26 @@ BOOST_AUTO_TEST_CASE(get_objects_details_with_plus_query_param) {
     clear_bucket(client, bucket_name);
     free_client(client);
 }
-*/
 
-/* Disabling from nightly test until network timeout failure is resolved */
-/*
-BOOST_AUTO_TEST_CASE(get_objects_details_with_special_chars_query_param) {
+BOOST_AUTO_TEST_CASE(get_objects_with_special_chars_query_param) {
     printf("-----Testing Search Object with special char-------\n");
 
     ds3_client* client = get_client();
     const char* bucket_name = "TestSpecialCharacterInObjectName";
     const char* special_char_object = "varsity1314/_projects/VARSITY 13-14/_versions/Varsity 13-14 (2015-10-05 1827)/_project/Trash/PCMAC HD.avb";
+    const char* local_file_to_put = "resources/beowulf.txt";
+    struct stat file_info;
+    memset(&file_info, 0, sizeof(struct stat));
+    uint64_t file_size = 0;
 
     ds3_error* bucket_error = create_bucket_with_data_policy(client, bucket_name, ids.data_policy_id->value);
     handle_error(bucket_error);
 
-    ds3_request* put_request = ds3_init_put_object_request(bucket_name, special_char_object, 1024);
-    FILE* obj_file = fopen("resources/beowulf.txt", "r");
+    stat(local_file_to_put, &file_info);
+    file_size = file_info.st_size;
+
+    ds3_request* put_request = ds3_init_put_object_request(bucket_name, special_char_object, file_size);
+    FILE* obj_file = fopen(local_file_to_put, "r");
 
     ds3_error* error = ds3_put_object_request(client, put_request, obj_file, ds3_read_from_file);
     ds3_request_free(put_request);
@@ -194,7 +204,6 @@ BOOST_AUTO_TEST_CASE(get_objects_details_with_special_chars_query_param) {
     clear_bucket(client, bucket_name);
     free_client(client);
 }
-*/
 
 BOOST_AUTO_TEST_CASE( get_folder_and_objects ) {
     uint64_t num_objs;


### PR DESCRIPTION
apply same patch to 3.0 as a previous change to 3_2_autogen branch: https://github.com/SpectraLogic/ds3_c_sdk/pull/155
