### PR TITLE
Set GLIB2_LIBRARIES to an absolute path when PkgConfig is used.

### DIFF
--- a/modules/FindGLIB2.cmake
+++ b/modules/FindGLIB2.cmake
@@ -42,6 +42,12 @@ ELSE (GLIB2_LIBRARIES AND GLIB2_INCLUDE_DIRS )
   ENDIF ( GLIB2_MIN_VERSION )
   IF ( PKG_CONFIG_FOUND )
     IF ( GLIB2_FOUND )
+      FIND_LIBRARY( _glib2_link_DIR
+                    NAMES glib-2.0 glib
+                    PATHS ${GLIB2_LIBRARY_DIRS} )
+      IF ( _glib2_link_DIR )
+        SET ( GLIB2_LIBRARIES ${_glib2_link_DIR} )
+      ENDIF ( _glib2_link_DIR )
       SET ( GLIB2_CORE_FOUND TRUE )
     ELSE ( GLIB2_FOUND )
       SET ( GLIB2_CORE_FOUND FALSE )


### PR DESCRIPTION
PkgConfig sets xxx_LIBRARIES to be just the name of the libraries without
the paths or file extensions and sets xxx_LIBRARY_DIRS to be the library
paths, however, target_link_libraries expects an absolute path.  This
uses FIND_LIBRARY after PkgConfig finds the library to get the absolute
path of the library and then override GLIB2_LIBRARIES.

See https://cmake.org/Bug/view.php?id=15804 for a bug that was
filed against CMake regarding this.