### PR TITLE
Also look in /usr/local/lib(/glib-2.0/include) for glibconfig.h, which

### DIFF
--- a/modules/FindGLIB2.cmake
+++ b/modules/FindGLIB2.cmake
@@ -69,6 +69,7 @@ ELSE (GLIB2_LIBRARIES AND GLIB2_INCLUDE_DIRS )
       /usr/lib64
       /usr/lib
       /usr/local/include
+      /usr/local/lib
       ${CMAKE_LIBRARY_PATH}
     PATH_SUFFIXES
       glib-2.0/include


### PR DESCRIPTION
is where it is on FreeBSD, when pkg-config is not available.