### PR TITLE
Fix formatting of uint64_t print specifier macro and CMake config

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -25,8 +25,7 @@ add_library(ds3 SHARED
 
 if (WIN32)
 
-    add_definitions(-DLIBRARY_EXPORTS -DCURL_STATICLIB -Dinline=__inline)
-    set_property(TARGET ds3 PROPERTY _CRT_SECURE_NO_WARNINGS)
+    add_definitions(-DLIBRARY_EXPORTS -DCURL_STATICLIB -Dinline=__inline -D__STDC_FORMAT_MACROS -D_CRT_SECURE_NO_WARNINGS)
     set_source_files_properties(ds3.c PROPERTIES LANGUAGE CXX)
 
     file(TO_NATIVE_PATH "${PROJECT_SOURCE_DIR}/win32" WINDOWS_DIR)

--- a/src/ds3.c
+++ b/src/ds3.c
@@ -42,6 +42,7 @@
 #include <unistd.h>
 #endif
 
+
 #ifndef S_ISDIR
 #define S_ISDIR(mode)  (((mode) & S_IFMT) == S_IFDIR)
 #endif
@@ -1157,7 +1158,7 @@ static void _set_query_param_flag(const ds3_request* _request, const char* key, 
 static void _set_query_param_uint64_t(const ds3_request* _request, const char* key, uint64_t value) {
     char string_buffer[UNSIGNED_LONG_LONG_BASE_10_STR_LEN];
     memset(string_buffer, 0, sizeof(string_buffer));
-    snprintf(string_buffer, sizeof(string_buffer), "%"PRIu64, value);
+    snprintf(string_buffer, sizeof(string_buffer), "%" PRIu64, value);
     _set_query_param(_request, key, string_buffer);
 }
 
@@ -3602,7 +3603,7 @@ static xmlDocPtr _generate_xml_bulk_objects_list(const ds3_bulk_object_list_resp
 
     for (obj_index = 0; obj_index < obj_list->num_objects; obj_index++) {
         obj = obj_list->objects[obj_index];
-        g_snprintf(size_buff, sizeof(char) * UNSIGNED_LONG_LONG_BASE_10_STR_LEN, "%"PRIu64, obj->length);
+        g_snprintf(size_buff, sizeof(char) * UNSIGNED_LONG_LONG_BASE_10_STR_LEN, "%" PRIu64, obj->length);
 
         object_node = xmlNewNode(NULL, (xmlChar*) "Object");
         xmlAddChild(objects_node, object_node);

--- a/src/ds3.h
+++ b/src/ds3.h
@@ -30,7 +30,6 @@
 #include "ds3_string_multimap.h"
 
 #ifdef __cplusplus
-#define __STDC_FORMAT_MACROS
 extern "C" {
 #endif
 
@@ -46,6 +45,7 @@ extern "C" {
 #endif
 
 #define DS3_READFUNC_ABORT CURL_READFUNC_ABORT
+
 
 typedef struct {
     int page_truncated;


### PR DESCRIPTION
Link:
  C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\link.exe /ERRORREPORT:QUEUE /OUT:"C:\Temp\ds3_c_sd
  output\bin\ds3.dll" /INCREMENTAL /NOLOGO kernel32.lib user32.lib gdi32.lib winspool.lib shell32.lib ole32.lib
  2.lib uuid.lib comdlg32.lib advapi32.lib ..\deps\install\lib\libcurl_a.lib ..\deps\install\lib\zlib_a.lib ..\
  tall\lib\libxml2_a.lib "..\deps\install\lib\glib-2.0.lib" Ws2_32.lib /MANIFEST /MANIFESTUAC:"level='asInvoker
  ss='false'" /manifest:embed /DEBUG /PDB:"C:/Temp/ds3_c_sdk/win32/output/bin/ds3.pdb" /SUBSYSTEM:CONSOLE /TLBI
  AMICBASE /NXCOMPAT /IMPLIB:"C:/Temp/ds3_c_sdk/win32/output/bin/ds3.lib" /MACHINE:X86 /SAFESEH  /machine:X86 /
  dir\Debug\ds3.obj
  ds3.dir\Debug\ds3_net.obj
  ds3.dir\Debug\ds3_string_multimap_impl.obj
  ds3.dir\Debug\ds3_string_multimap.obj
  ds3.dir\Debug\ds3_string.obj
  ds3.dir\Debug\ds3_utils.obj
  ds3.dir\Debug\ds3_connection.obj
     Creating library C:/Temp/ds3_c_sdk/win32/output/bin/ds3.lib and object C:/Temp/ds3_c_sdk/win32/output/bin/
LINK : warning LNK4098: defaultlib 'MSVCRT' conflicts with use of other libs; use /NODEFAULTLIB:library [C:\Tem
sdk\win32\src\ds3.vcxproj]
ds3.obj : warning LNK4049: locally defined symbol _xmlFree imported [C:\Temp\ds3_c_sdk\win32\src\ds3.vcxproj]
  ds3.vcxproj -> C:\Temp\ds3_c_sdk\win32\output\bin\ds3.dll
PostBuildEvent:
  setlocal
  copy C:\Temp\ds3_c_sdk\win32\output\bin\ds3.dll C:\Temp\ds3_c_sdk\test\bin
  if %errorlevel% neq 0 goto :cmEnd
  :cmEnd
  endlocal & call :cmErrorLevel %errorlevel% & goto :cmDone
  :cmErrorLevel
  exit /b %1
  :cmDone
  if %errorlevel% neq 0 goto :VCEnd
  :VCEnd
          1 file(s) copied.
FinalizeBuildStatus:
  Deleting file "ds3.dir\Debug\ds3.tlog\unsuccessfulbuild".
  Touching "ds3.dir\Debug\ds3.tlog\ds3.lastbuildstate".
Done Building Project "C:\Temp\ds3_c_sdk\win32\src\ds3.vcxproj" (default targets).

Done Building Project "C:\Temp\ds3_c_sdk\win32\src\ds3.vcxproj.metaproj" (default targets).

Done Building Project "C:\Temp\ds3_c_sdk\win32\libds3.sln" (default targets).


Build succeeded.
