### PR TITLE
Fix formatting of uint64_t print specifier macro and CMake config

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -25,9 +25,8 @@ add_library(ds3 SHARED
 
 if (WIN32)
 
-add_definitions(-DLIBRARY_EXPORTS -DCURL_STATICLIB -Dinline=__inline)
-set_property(TARGET ds3 PROPERTY _CRT_SECURE_NO_WARNINGS)
-SET_SOURCE_FILES_PROPERTIES(ds3.c PROPERTIES LANGUAGE CXX)
+    add_definitions(-DLIBRARY_EXPORTS -DCURL_STATICLIB -Dinline=__inline -D__STDC_FORMAT_MACROS -D_CRT_SECURE_NO_WARNINGS)
+    set_source_files_properties(ds3.c PROPERTIES LANGUAGE CXX)
 
 include_directories(
     ../win32/deps/install/include

--- a/src/ds3.c
+++ b/src/ds3.c
@@ -42,6 +42,7 @@
 #include <unistd.h>
 #endif
 
+
 #ifndef S_ISDIR
 #define S_ISDIR(mode)  (((mode) & S_IFMT) == S_IFDIR)
 #endif
@@ -1227,7 +1228,7 @@ static void _set_query_param_flag(const ds3_request* _request, const char* key, 
 static void _set_query_param_uint64_t(const ds3_request* _request, const char* key, uint64_t value) {
     char string_buffer[UNSIGNED_LONG_LONG_BASE_10_STR_LEN];
     memset(string_buffer, 0, sizeof(string_buffer));
-    snprintf(string_buffer, sizeof(string_buffer), "%"PRIu64, value);
+    snprintf(string_buffer, sizeof(string_buffer), "%" PRIu64, value);
     _set_query_param(_request, key, string_buffer);
 }
 
@@ -4168,7 +4169,7 @@ static xmlDocPtr _generate_xml_bulk_objects_list(const ds3_bulk_object_list_resp
 
     for (obj_index = 0; obj_index < obj_list->num_objects; obj_index++) {
         obj = obj_list->objects[obj_index];
-        g_snprintf(size_buff, sizeof(char) * UNSIGNED_LONG_LONG_BASE_10_STR_LEN, "%"PRIu64, obj->length);
+        g_snprintf(size_buff, sizeof(char) * UNSIGNED_LONG_LONG_BASE_10_STR_LEN, "%" PRIu64, obj->length);
 
         object_node = xmlNewNode(NULL, (xmlChar*) "Object");
         xmlAddChild(objects_node, object_node);

--- a/src/ds3.h
+++ b/src/ds3.h
@@ -30,7 +30,6 @@
 #include "ds3_string_multimap.h"
 
 #ifdef __cplusplus
-#define __STDC_FORMAT_MACROS
 extern "C" {
 #endif
 
@@ -46,6 +45,7 @@ extern "C" {
 #endif
 
 #define DS3_READFUNC_ABORT CURL_READFUNC_ABORT
+
 
 typedef struct {
     int page_truncated;


### PR DESCRIPTION
```
denverm@dm-lt:~/code/ds3_c_sdk$ make
-- Configuring done
-- Generating done
-- Build files have been written to: /home/denverm/code/ds3_c_sdk
Scanning dependencies of target ds3
[ 12%] Building C object src/CMakeFiles/ds3.dir/ds3.c.o
[ 25%] Building C object src/CMakeFiles/ds3.dir/ds3_net.c.o
[ 37%] Building C object src/CMakeFiles/ds3.dir/ds3_string_multimap_impl.c.o
[ 50%] Building C object src/CMakeFiles/ds3.dir/ds3_string_multimap.c.o
[ 62%] Building C object src/CMakeFiles/ds3.dir/ds3_string.c.o
[ 75%] Building C object src/CMakeFiles/ds3.dir/ds3_utils.c.o
[ 87%] Building C object src/CMakeFiles/ds3.dir/ds3_connection.c.o
[100%] Linking C shared library libds3.so
[100%] Built target ds3
denverm@dm-lt:~/code/ds3_c_sdk$ cd test
denverm@dm-lt:~/code/ds3_c_sdk/test$ make clean
denverm@dm-lt:~/code/ds3_c_sdk/test$ make
Scanning dependencies of target ds3_c_test
[  7%] Building CXX object CMakeFiles/ds3_c_test.dir/bucket_tests.cpp.o
[ 14%] Building CXX object CMakeFiles/ds3_c_test.dir/bulk_get.cpp.o
[ 21%] Building CXX object CMakeFiles/ds3_c_test.dir/bulk_put.cpp.o
[ 28%] Building CXX object CMakeFiles/ds3_c_test.dir/checksum.cpp.o
[ 35%] Building CXX object CMakeFiles/ds3_c_test.dir/deletes_test.cpp.o
[ 42%] Building CXX object CMakeFiles/ds3_c_test.dir/get_physical_placement.cpp.o
[ 50%] Building CXX object CMakeFiles/ds3_c_test.dir/job_tests.cpp.o
[ 57%] Building CXX object CMakeFiles/ds3_c_test.dir/metadata_tests.cpp.o
[ 64%] Building CXX object CMakeFiles/ds3_c_test.dir/multimap_tests.cpp.o
[ 71%] Building CXX object CMakeFiles/ds3_c_test.dir/negative_tests.cpp.o
[ 78%] Building CXX object CMakeFiles/ds3_c_test.dir/search_tests.cpp.o
[ 85%] Building CXX object CMakeFiles/ds3_c_test.dir/service_tests.cpp.o
[ 92%] Building CXX object CMakeFiles/ds3_c_test.dir/test.cpp.o
[100%] Linking CXX executable ds3_c_test
[100%] Built target ds3_c_test
denverm@dm-lt:~/code/ds3_c_sdk/test$ 
```