### PR TITLE
add mem target to run tests with valgrind

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -58,9 +58,10 @@ else(WIN32) # POSIX
 
   link_directories("${PROJECT_SOURCE_DIR}/../install/lib")
   include_directories("${PROJECT_SOURCE_DIR}/../install/include")
+
 endif(WIN32)
 
-add_executable(ds3_c_test
+add_executable(ds3_c_tests
   bucket_tests.cpp
   bulk_get.cpp
   bulk_put.cpp
@@ -75,7 +76,12 @@ add_executable(ds3_c_test
   service_tests.cpp
   test.cpp)
 
-add_test(regression_tests ds3_c_test)
+add_test(regression_tests ds3_c_tests)
 
-target_link_libraries(ds3_c_test ds3 glib-2.0 boost_unit_test_framework)
+target_link_libraries(ds3_c_tests ds3 glib-2.0 boost_unit_test_framework)
 
+find_program(VALGRIND "valgrind")
+if(VALGRIND)
+  add_custom_target(mem
+  COMMAND "${VALGRIND}" --tool=memcheck  --leak-check=full --track-origins=yes --show-leak-kinds=all $<TARGET_FILE:ds3_c_tests> )  # --show-reachable=yes --num-callers=20 --track-fds=yes
+endif()


### PR DESCRIPTION
denverm@dm-lt:~/code/ds3_c_sdk/test$ make
-- Found glib-2.0
-- Configuring done
-- Generating done
-- Build files have been written to: /home/denverm/code/ds3_c_sdk/test
Scanning dependencies of target ds3_c_tests
[  7%] Building CXX object CMakeFiles/ds3_c_tests.dir/bucket_tests.cpp.o
[ 14%] Building CXX object CMakeFiles/ds3_c_tests.dir/bulk_get.cpp.o
[ 21%] Building CXX object CMakeFiles/ds3_c_tests.dir/bulk_put.cpp.o
[ 28%] Building CXX object CMakeFiles/ds3_c_tests.dir/checksum.cpp.o
[ 35%] Building CXX object CMakeFiles/ds3_c_tests.dir/deletes_test.cpp.o
[ 42%] Building CXX object CMakeFiles/ds3_c_tests.dir/get_physical_placement.cpp.o
[ 50%] Building CXX object CMakeFiles/ds3_c_tests.dir/job_tests.cpp.o
[ 57%] Building CXX object CMakeFiles/ds3_c_tests.dir/metadata_tests.cpp.o
[ 64%] Building CXX object CMakeFiles/ds3_c_tests.dir/multimap_tests.cpp.o
[ 71%] Building CXX object CMakeFiles/ds3_c_tests.dir/negative_tests.cpp.o
[ 78%] Building CXX object CMakeFiles/ds3_c_tests.dir/search_tests.cpp.o
[ 85%] Building CXX object CMakeFiles/ds3_c_tests.dir/service_tests.cpp.o
[ 92%] Building CXX object CMakeFiles/ds3_c_tests.dir/test.cpp.o
[100%] Linking CXX executable ds3_c_tests
[100%] Built target ds3_c_tests
denverm@dm-lt:~/code/ds3_c_sdk/test$ make mem
[100%] Built target ds3_c_tests
Scanning dependencies of target mem
==8804== Memcheck, a memory error detector
==8804== Copyright (C) 2002-2015, and GNU GPL'd, by Julian Seward et al.
==8804== Using Valgrind-3.11.0 and LibVEX; rerun with -h for copyright info
==8804== Command: /home/denverm/code/ds3_c_sdk/test/ds3_c_tests
==8804== 
Running 64 test cases...
-----Testing Bulk PUT-------
-----Testing put empty folder-------
-----Testing Prefix-------
-----Testing Delimiter-------
-----Testing CommonPrefixes-------
-----Testing Marker-------
-----Testing Max-Keys-------
-----Testing Bulk GET-------
------Performing Data Integrity Test-------
Original file:	resources/beowulf.txt
File to be checked:	resources/temp-beowulf.txt
resources/beowulf.txt(checksum):ac2bbbe752fac61079cf22feb286b77e
resources/temp-beowulf.txt(checksum):ac2bbbe752fac61079cf22feb286b77e
Data Integrity Test Passed...MD5 Checksum is Same for Both Files
------Performing Data Integrity Test-------
Original file:	resources/sherlock_holmes.txt
File to be checked:	resources/temp-sherlock_holmes.txt
resources/sherlock_holmes.txt(checksum):0bfc07b888d354413cfb662651a0ad8d
resources/temp-sherlock_holmes.txt(checksum):0bfc07b888d354413cfb662651a0ad8d
Data Integrity Test Passed...MD5 Checksum is Same for Both Files
------Performing Data Integrity Test-------
Original file:	resources/tale_of_two_cities.txt
File to be checked:	resources/temp-tale_of_two_cities.txt
resources/tale_of_two_cities.txt(checksum):8c8c9e07ed8a4e10c497bd512441f695
resources/temp-tale_of_two_cities.txt(checksum):8c8c9e07ed8a4e10c497bd512441f695
Data Integrity Test Passed...MD5 Checksum is Same for Both Files
------Performing Data Integrity Test-------
Original file:	resources/ulysses.txt
File to be checked:	resources/temp-ulysses.txt
resources/ulysses.txt(checksum):b5d34c938d4e1ef30000c8c95f260e8e
resources/temp-ulysses.txt(checksum):b5d34c938d4e1ef30000c8c95f260e8e
Data Integrity Test Passed...MD5 Checksum is Same for Both Files
------Performing Data Integrity Test-------
Original file:	resources/ulysses_large.txt
File to be checked:	resources/temp-ulysses_large.txt
resources/ulysses_large.txt(checksum):382f14f853b0fcee2b1514ab47eee6f8
resources/temp-ulysses_large.txt(checksum):382f14f853b0fcee2b1514ab47eee6f8
Data Integrity Test Passed...MD5 Checksum is Same for Both Files
-----Testing Bulk GET with max_upload_size-------
------Performing Data Integrity Test-------
Original file:	resources/beowulf.txt
File to be checked:	resources/temp-beowulf.txt
resources/beowulf.txt(checksum):ac2bbbe752fac61079cf22feb286b77e
resources/temp-beowulf.txt(checksum):ac2bbbe752fac61079cf22feb286b77e
Data Integrity Test Passed...MD5 Checksum is Same for Both Files
------Performing Data Integrity Test-------
Original file:	resources/sherlock_holmes.txt
File to be checked:	resources/temp-sherlock_holmes.txt
resources/sherlock_holmes.txt(checksum):0bfc07b888d354413cfb662651a0ad8d
resources/temp-sherlock_holmes.txt(checksum):0bfc07b888d354413cfb662651a0ad8d
Data Integrity Test Passed...MD5 Checksum is Same for Both Files
------Performing Data Integrity Test-------
Original file:	resources/tale_of_two_cities.txt
File to be checked:	resources/temp-tale_of_two_cities.txt
resources/tale_of_two_cities.txt(checksum):8c8c9e07ed8a4e10c497bd512441f695
resources/temp-tale_of_two_cities.txt(checksum):8c8c9e07ed8a4e10c497bd512441f695
Data Integrity Test Passed...MD5 Checksum is Same for Both Files
------Performing Data Integrity Test-------
Original file:	resources/ulysses.txt
File to be checked:	resources/temp-ulysses.txt
resources/ulysses.txt(checksum):b5d34c938d4e1ef30000c8c95f260e8e
resources/temp-ulysses.txt(checksum):b5d34c938d4e1ef30000c8c95f260e8e
Data Integrity Test Passed...MD5 Checksum is Same for Both Files
------Performing Data Integrity Test-------
Original file:	resources/ulysses_46mb.txt
File to be checked:	resources/temp-ulysses_46mb.txt
resources/ulysses_46mb.txt(checksum):2b69d745454e3ae53fa62274155b5b2e
resources/temp-ulysses_46mb.txt(checksum):2b69d745454e3ae53fa62274155b5b2e
Data Integrity Test Passed...MD5 Checksum is Same for Both Files
------Performing Data Integrity Test-------
Original file:	resources/ulysses_large.txt
File to be checked:	resources/temp-ulysses_large.txt
resources/ulysses_large.txt(checksum):382f14f853b0fcee2b1514ab47eee6f8
resources/temp-ulysses_large.txt(checksum):382f14f853b0fcee2b1514ab47eee6f8
Data Integrity Test Passed...MD5 Checksum is Same for Both Files
-----Testing Bulk GET with chunk_preference-------
------Performing Data Integrity Test-------
Original file:	resources/beowulf.txt
File to be checked:	resources/temp-beowulf.txt
resources/beowulf.txt(checksum):ac2bbbe752fac61079cf22feb286b77e
resources/temp-beowulf.txt(checksum):ac2bbbe752fac61079cf22feb286b77e
Data Integrity Test Passed...MD5 Checksum is Same for Both Files
------Performing Data Integrity Test-------
Original file:	resources/sherlock_holmes.txt
File to be checked:	resources/temp-sherlock_holmes.txt
resources/sherlock_holmes.txt(checksum):0bfc07b888d354413cfb662651a0ad8d
resources/temp-sherlock_holmes.txt(checksum):0bfc07b888d354413cfb662651a0ad8d
Data Integrity Test Passed...MD5 Checksum is Same for Both Files
------Performing Data Integrity Test-------
Original file:	resources/tale_of_two_cities.txt
File to be checked:	resources/temp-tale_of_two_cities.txt
resources/tale_of_two_cities.txt(checksum):8c8c9e07ed8a4e10c497bd512441f695
resources/temp-tale_of_two_cities.txt(checksum):8c8c9e07ed8a4e10c497bd512441f695
Data Integrity Test Passed...MD5 Checksum is Same for Both Files
------Performing Data Integrity Test-------
Original file:	resources/ulysses.txt
File to be checked:	resources/temp-ulysses.txt
resources/ulysses.txt(checksum):b5d34c938d4e1ef30000c8c95f260e8e
resources/temp-ulysses.txt(checksum):b5d34c938d4e1ef30000c8c95f260e8e
Data Integrity Test Passed...MD5 Checksum is Same for Both Files
------Performing Data Integrity Test-------
Original file:	resources/ulysses_large.txt
File to be checked:	resources/temp-ulysses_large.txt
resources/ulysses_large.txt(checksum):382f14f853b0fcee2b1514ab47eee6f8
resources/temp-ulysses_large.txt(checksum):382f14f853b0fcee2b1514ab47eee6f8
Data Integrity Test Passed...MD5 Checksum is Same for Both Files
-----Testing Bulk GET with partial range-------
------Performing Data Integrity Test-------
Original file:	resources/beowulf.txt
File to be checked:	resources/temp-beowulf.txt
resources/beowulf.txt(checksum):f36d441d5809802fa7095b9a1110d3e4
resources/temp-beowulf.txt(checksum):f36d441d5809802fa7095b9a1110d3e4
Data Integrity Test Passed...MD5 Checksum is Same for Both Files
Original file:	resources/beowulf.txt
File to be checked:	resources/temp-beowulf.txt
resources/beowulf.txt(checksum):4026b4a7c4e0e3751a565268d1db450a
resources/temp-beowulf.txt(checksum):4026b4a7c4e0e3751a565268d1db450a
Data Integrity Test Passed...MD5 Checksum is Same for Both Files
------Performing Data Integrity Test-------
Original file:	resources/sherlock_holmes.txt
File to be checked:	resources/temp-sherlock_holmes.txt
resources/sherlock_holmes.txt(checksum):99f647da54d2afeab12c72f6d74c2cb9
resources/temp-sherlock_holmes.txt(checksum):99f647da54d2afeab12c72f6d74c2cb9
Data Integrity Test Passed...MD5 Checksum is Same for Both Files
Original file:	resources/sherlock_holmes.txt
File to be checked:	resources/temp-sherlock_holmes.txt
resources/sherlock_holmes.txt(checksum):d245102a3b1d93f72a168efed0855d14
resources/temp-sherlock_holmes.txt(checksum):d245102a3b1d93f72a168efed0855d14
Data Integrity Test Passed...MD5 Checksum is Same for Both Files
------Performing Data Integrity Test-------
Original file:	resources/tale_of_two_cities.txt
File to be checked:	resources/temp-tale_of_two_cities.txt
resources/tale_of_two_cities.txt(checksum):3d9fd3675608a5ba6b33fd43985eae60
resources/temp-tale_of_two_cities.txt(checksum):3d9fd3675608a5ba6b33fd43985eae60
Data Integrity Test Passed...MD5 Checksum is Same for Both Files
Original file:	resources/tale_of_two_cities.txt
File to be checked:	resources/temp-tale_of_two_cities.txt
resources/tale_of_two_cities.txt(checksum):b7e608930165d7950a9af10a6ba83c02
resources/temp-tale_of_two_cities.txt(checksum):b7e608930165d7950a9af10a6ba83c02
Data Integrity Test Passed...MD5 Checksum is Same for Both Files
------Performing Data Integrity Test-------
Original file:	resources/ulysses.txt
File to be checked:	resources/temp-ulysses.txt
resources/ulysses.txt(checksum):cb6c8072850aae19311d988d27c885e4
resources/temp-ulysses.txt(checksum):cb6c8072850aae19311d988d27c885e4
Data Integrity Test Passed...MD5 Checksum is Same for Both Files
Original file:	resources/ulysses.txt
File to be checked:	resources/temp-ulysses.txt
resources/ulysses.txt(checksum):eac30dcb533f1a8d83b1c8a8b3896924
resources/temp-ulysses.txt(checksum):eac30dcb533f1a8d83b1c8a8b3896924
Data Integrity Test Passed...MD5 Checksum is Same for Both Files
------Performing Data Integrity Test-------
Original file:	resources/ulysses_large.txt
File to be checked:	resources/temp-ulysses_large.txt
resources/ulysses_large.txt(checksum):99e7096f524cf84c995a0cf7d5083f24
resources/temp-ulysses_large.txt(checksum):99e7096f524cf84c995a0cf7d5083f24
Data Integrity Test Passed...MD5 Checksum is Same for Both Files
Original file:	resources/ulysses_large.txt
File to be checked:	resources/temp-ulysses_large.txt
resources/ulysses_large.txt(checksum):8fcd6828e0b8141af37a40db7fc201ad
resources/temp-ulysses_large.txt(checksum):8fcd6828e0b8141af37a40db7fc201ad
Data Integrity Test Passed...MD5 Checksum is Same for Both Files
-----Testing escape url helpers-------
-----Testing convert_list helper-------
-----Testing directory size on convert list helper-------
-----Testing Bulk PUT of 10k very small files-------
-----Testing Bulk PUT of 200 very small files multithreaded-------
-----Testing PUT object with UTF Characters in name-------
-----Testing PUT objects with 64bit object sizes in name-------

-----Testing GetPhysicalPlacement -------
-----Testing Get Job-------
-----Testing Cancel Job-------
-----Testing Get Jobs-------
-----Testing GetJobToReplicateRequestHandler response type parsing-------
-----Testing put_metadata-------
creating metadata entry of: name
-----Testing put_emtpy_metadata-------
Ignoring metadata key "name" which has a NULL or empty value.
-----Testing put_null_metadata-------
Ignoring metadata key "name" which has a NULL or empty value.
-----Testing head_bucket-------
-----Testing head_folder-------
-----Testing put_multiple_metadata_items-------
creating metadata entry of: name
creating metadata entry of: key
-----Testing metadata_keys-------
creating metadata entry of: name
creating metadata entry of: key
-----Testing put_metadata_using_get_object_retrieval-------
creating metadata entry of: name
-----Testing string_multimap insert_and_lookup-------
-----Negative Testing Duplicate Bucket Creation-------
-----Negative Testing Non Existing Bucket Deletion-------
-----Negative Testing get_bucket with empty bucket_name parameter-------
-----Negative Testing get_bucket with null bucket_name parameter-------
-----Negative Testing head_object with empty object_name parameter-------
-----Negative Testing head_object with null object_name parameter-------
-----Negative Testing Non Existing Head Bucket-------
-----Negative Testing Non Existing Object Deletion-------
-----Negative Testing Bad Bucket Name creation-------
-----Negative Testing get_bucket with bucket_name/ with trailing slash-------
-----Negative Testing Object List With Duplicate Objects Creation-------
-----Negative Testing Put Empty Object List-------
-----Negative Testing Multiple Delete Jobs-------
-----Negative Testing Non Existing Get Job-------
-----Testing get_objects_with_full_details-------
-----Testing Search Object with +-------
-----Testing Search Object with special char-------
-----Testing get_objects_details_paging-------
-----Testing GET service-------
-----Testing GET service after PUT bucket-------
Expected Name (test_put_bucket) actual (test_put_bucket)
-----Testing GET system_information-------
-----Testing VerifySystemHealth-------

*** No errors detected
==8804== 
==8804== HEAP SUMMARY:
==8804==     in use at exit: 91,618 bytes in 17 blocks
==8804==   total heap usage: 4,667,977 allocs, 4,667,960 frees, 2,942,539,331 bytes allocated
==8804== 
==8804== 4 bytes in 1 blocks are still reachable in loss record 1 of 17
==8804==    at 0x4C2DB8F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==8804==    by 0x5150132: ??? (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.4800.2)
==8804==    by 0x5150674: g_private_get (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.4800.2)
==8804==    by 0x51288FC: g_slice_alloc (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.4800.2)
==8804==    by 0x50FA74D: g_hash_table_new_full (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.4800.2)
==8804==    by 0x511B8AA: ??? (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.4800.2)
==8804==    by 0x40104E9: call_init.part.0 (dl-init.c:72)
==8804==    by 0x40105FA: call_init (dl-init.c:30)
==8804==    by 0x40105FA: _dl_init (dl-init.c:120)
==8804==    by 0x4000CF9: ??? (in /lib/x86_64-linux-gnu/ld-2.23.so)
==8804== 
==8804== 4 bytes in 1 blocks are still reachable in loss record 2 of 17
==8804==    at 0x4C2DB8F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==8804==    by 0x5150132: ??? (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.4800.2)
==8804==    by 0x5150674: g_private_get (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.4800.2)
==8804==    by 0x50E7898: g_get_charset (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.4800.2)
==8804==    by 0x50F6956: g_date_time_format (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.4800.2)
==8804==    by 0x4EA5123: _generate_date_string (in /usr/local/lib/libds3.so)
==8804==    by 0x4EA61D5: net_process_request (in /usr/local/lib/libds3.so)
==8804==    by 0x4E60CD5: _internal_request_dispatcher (in /usr/local/lib/libds3.so)
==8804==    by 0x4E8D31C: ds3_put_data_policy_spectra_s3_request (in /usr/local/lib/libds3.so)
==8804==    by 0x548D49: configure_for_tests() (test.cpp:91)
==8804==    by 0x564218: BoostTestFixture::BoostTestFixture() (test.cpp:30)
==8804==    by 0x5A3C7B: boost::unit_test::ut_detail::global_fixture_impl<BoostTestFixture>::test_start(unsigned long) (in /home/denverm/code/ds3_c_sdk/test/ds3_c_tests)
==8804== 
==8804== 4 bytes in 1 blocks are still reachable in loss record 3 of 17
==8804==    at 0x4C2DB8F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==8804==    by 0x5150132: ??? (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.4800.2)
==8804==    by 0x51506F0: g_private_set (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.4800.2)
==8804==    by 0x5132B77: ??? (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.4800.2)
==8804==    by 0x65D46B9: start_thread (pthread_create.c:333)
==8804==    by 0x5A7182C: clone (clone.S:109)
==8804== 
==8804== 15 bytes in 1 blocks are still reachable in loss record 4 of 17
==8804==    at 0x4C2DB8F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==8804==    by 0x5111718: g_malloc (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.4800.2)
==8804==    by 0x512A4EE: g_strdup (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.4800.2)
==8804==    by 0x50E7918: g_get_charset (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.4800.2)
==8804==    by 0x50F6956: g_date_time_format (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.4800.2)
==8804==    by 0x4EA5123: _generate_date_string (in /usr/local/lib/libds3.so)
==8804==    by 0x4EA61D5: net_process_request (in /usr/local/lib/libds3.so)
==8804==    by 0x4E60CD5: _internal_request_dispatcher (in /usr/local/lib/libds3.so)
==8804==    by 0x4E8D31C: ds3_put_data_policy_spectra_s3_request (in /usr/local/lib/libds3.so)
==8804==    by 0x548D49: configure_for_tests() (test.cpp:91)
==8804==    by 0x564218: BoostTestFixture::BoostTestFixture() (test.cpp:30)
==8804==    by 0x5A3C7B: boost::unit_test::ut_detail::global_fixture_impl<BoostTestFixture>::test_start(unsigned long) (in /home/denverm/code/ds3_c_sdk/test/ds3_c_tests)
==8804== 
==8804== 15 bytes in 1 blocks are still reachable in loss record 5 of 17
==8804==    at 0x4C2DB8F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==8804==    by 0x5111718: g_malloc (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.4800.2)
==8804==    by 0x512A4EE: g_strdup (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.4800.2)
==8804==    by 0x50E7985: g_get_charset (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.4800.2)
==8804==    by 0x50F6956: g_date_time_format (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.4800.2)
==8804==    by 0x4EA5123: _generate_date_string (in /usr/local/lib/libds3.so)
==8804==    by 0x4EA61D5: net_process_request (in /usr/local/lib/libds3.so)
==8804==    by 0x4E60CD5: _internal_request_dispatcher (in /usr/local/lib/libds3.so)
==8804==    by 0x4E8D31C: ds3_put_data_policy_spectra_s3_request (in /usr/local/lib/libds3.so)
==8804==    by 0x548D49: configure_for_tests() (test.cpp:91)
==8804==    by 0x564218: BoostTestFixture::BoostTestFixture() (test.cpp:30)
==8804==    by 0x5A3C7B: boost::unit_test::ut_detail::global_fixture_impl<BoostTestFixture>::test_start(unsigned long) (in /home/denverm/code/ds3_c_sdk/test/ds3_c_tests)
==8804== 
==8804== 24 bytes in 1 blocks are still reachable in loss record 6 of 17
==8804==    at 0x4C2FB55: calloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==8804==    by 0x5111770: g_malloc0 (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.4800.2)
==8804==    by 0x50E79A9: g_get_charset (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.4800.2)
==8804==    by 0x50F6956: g_date_time_format (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.4800.2)
==8804==    by 0x4EA5123: _generate_date_string (in /usr/local/lib/libds3.so)
==8804==    by 0x4EA61D5: net_process_request (in /usr/local/lib/libds3.so)
==8804==    by 0x4E60CD5: _internal_request_dispatcher (in /usr/local/lib/libds3.so)
==8804==    by 0x4E8D31C: ds3_put_data_policy_spectra_s3_request (in /usr/local/lib/libds3.so)
==8804==    by 0x548D49: configure_for_tests() (test.cpp:91)
==8804==    by 0x564218: BoostTestFixture::BoostTestFixture() (test.cpp:30)
==8804==    by 0x5A3C7B: boost::unit_test::ut_detail::global_fixture_impl<BoostTestFixture>::test_start(unsigned long) (in /home/denverm/code/ds3_c_sdk/test/ds3_c_tests)
==8804==    by 0x55BED7: boost::unit_test::ut_detail::test_start_caller::operator()() (framework.ipp:71)
==8804== 
==8804== 32 bytes in 1 blocks are still reachable in loss record 7 of 17
==8804==    at 0x4C2FB55: calloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==8804==    by 0x5111770: g_malloc0 (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.4800.2)
==8804==    by 0x50FA7B4: g_hash_table_new_full (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.4800.2)
==8804==    by 0x511B8AA: ??? (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.4800.2)
==8804==    by 0x40104E9: call_init.part.0 (dl-init.c:72)
==8804==    by 0x40105FA: call_init (dl-init.c:30)
==8804==    by 0x40105FA: _dl_init (dl-init.c:120)
==8804==    by 0x4000CF9: ??? (in /lib/x86_64-linux-gnu/ld-2.23.so)
==8804== 
==8804== 32 bytes in 1 blocks are still reachable in loss record 8 of 17
==8804==    at 0x4C2DB8F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==8804==    by 0x7BE1E77: CRYPTO_malloc (in /lib/x86_64-linux-gnu/libcrypto.so.1.0.0)
==8804==    by 0x7C98AFE: sk_new (in /lib/x86_64-linux-gnu/libcrypto.so.1.0.0)
==8804==    by 0x795A4E9: ??? (in /lib/x86_64-linux-gnu/libssl.so.1.0.0)
==8804==    by 0x795C5E8: SSL_COMP_get_compression_methods (in /lib/x86_64-linux-gnu/libssl.so.1.0.0)
==8804==    by 0x7961D72: SSL_library_init (in /lib/x86_64-linux-gnu/libssl.so.1.0.0)
==8804==    by 0x6141205: ??? (in /usr/lib/x86_64-linux-gnu/libcurl.so.4.4.0)
==8804==    by 0x611B4D4: ??? (in /usr/lib/x86_64-linux-gnu/libcurl.so.4.4.0)
==8804==    by 0x4EA4D32: _init_curl (in /usr/local/lib/libds3.so)
==8804==    by 0x4EA5C3C: net_process_request (in /usr/local/lib/libds3.so)
==8804==    by 0x4E60CD5: _internal_request_dispatcher (in /usr/local/lib/libds3.so)
==8804==    by 0x4E8D31C: ds3_put_data_policy_spectra_s3_request (in /usr/local/lib/libds3.so)
==8804== 
==8804== 32 bytes in 1 blocks are still reachable in loss record 9 of 17
==8804==    at 0x4C2DB8F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==8804==    by 0x7BE1E77: CRYPTO_malloc (in /lib/x86_64-linux-gnu/libcrypto.so.1.0.0)
==8804==    by 0x7C98B1C: sk_new (in /lib/x86_64-linux-gnu/libcrypto.so.1.0.0)
==8804==    by 0x795A4E9: ??? (in /lib/x86_64-linux-gnu/libssl.so.1.0.0)
==8804==    by 0x795C5E8: SSL_COMP_get_compression_methods (in /lib/x86_64-linux-gnu/libssl.so.1.0.0)
==8804==    by 0x7961D72: SSL_library_init (in /lib/x86_64-linux-gnu/libssl.so.1.0.0)
==8804==    by 0x6141205: ??? (in /usr/lib/x86_64-linux-gnu/libcurl.so.4.4.0)
==8804==    by 0x611B4D4: ??? (in /usr/lib/x86_64-linux-gnu/libcurl.so.4.4.0)
==8804==    by 0x4EA4D32: _init_curl (in /usr/local/lib/libds3.so)
==8804==    by 0x4EA5C3C: net_process_request (in /usr/local/lib/libds3.so)
==8804==    by 0x4E60CD5: _internal_request_dispatcher (in /usr/local/lib/libds3.so)
==8804==    by 0x4E8D31C: ds3_put_data_policy_spectra_s3_request (in /usr/local/lib/libds3.so)
==8804== 
==8804== 32 bytes in 1 blocks are still reachable in loss record 10 of 17
==8804==    at 0x4C2FB55: calloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==8804==    by 0x5111770: g_malloc0 (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.4800.2)
==8804==    by 0x50FA7B4: g_hash_table_new_full (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.4800.2)
==8804==    by 0x5135762: g_time_zone_new (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.4800.2)
==8804==    by 0x50F413A: g_date_time_new_now_local (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.4800.2)
==8804==    by 0x4EA510C: _generate_date_string (in /usr/local/lib/libds3.so)
==8804==    by 0x4EA61D5: net_process_request (in /usr/local/lib/libds3.so)
==8804==    by 0x4E60CD5: _internal_request_dispatcher (in /usr/local/lib/libds3.so)
==8804==    by 0x4E8D31C: ds3_put_data_policy_spectra_s3_request (in /usr/local/lib/libds3.so)
==8804==    by 0x548D49: configure_for_tests() (test.cpp:91)
==8804==    by 0x564218: BoostTestFixture::BoostTestFixture() (test.cpp:30)
==8804==    by 0x5A3C7B: boost::unit_test::ut_detail::global_fixture_impl<BoostTestFixture>::test_start(unsigned long) (in /home/denverm/code/ds3_c_sdk/test/ds3_c_tests)
==8804== 
==8804== 64 bytes in 1 blocks are still reachable in loss record 11 of 17
==8804==    at 0x4C2FB55: calloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==8804==    by 0x5111770: g_malloc0 (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.4800.2)
==8804==    by 0x50FA79F: g_hash_table_new_full (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.4800.2)
==8804==    by 0x511B8AA: ??? (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.4800.2)
==8804==    by 0x40104E9: call_init.part.0 (dl-init.c:72)
==8804==    by 0x40105FA: call_init (dl-init.c:30)
==8804==    by 0x40105FA: _dl_init (dl-init.c:120)
==8804==    by 0x4000CF9: ??? (in /lib/x86_64-linux-gnu/ld-2.23.so)
==8804== 
==8804== 64 bytes in 1 blocks are still reachable in loss record 12 of 17
==8804==    at 0x4C2FB55: calloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==8804==    by 0x5111770: g_malloc0 (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.4800.2)
==8804==    by 0x50FA79F: g_hash_table_new_full (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.4800.2)
==8804==    by 0x5135762: g_time_zone_new (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.4800.2)
==8804==    by 0x50F413A: g_date_time_new_now_local (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.4800.2)
==8804==    by 0x4EA510C: _generate_date_string (in /usr/local/lib/libds3.so)
==8804==    by 0x4EA61D5: net_process_request (in /usr/local/lib/libds3.so)
==8804==    by 0x4E60CD5: _internal_request_dispatcher (in /usr/local/lib/libds3.so)
==8804==    by 0x4E8D31C: ds3_put_data_policy_spectra_s3_request (in /usr/local/lib/libds3.so)
==8804==    by 0x548D49: configure_for_tests() (test.cpp:91)
==8804==    by 0x564218: BoostTestFixture::BoostTestFixture() (test.cpp:30)
==8804==    by 0x5A3C7B: boost::unit_test::ut_detail::global_fixture_impl<BoostTestFixture>::test_start(unsigned long) (in /home/denverm/code/ds3_c_sdk/test/ds3_c_tests)
==8804== 
==8804== 88 bytes in 1 blocks are still reachable in loss record 13 of 17
==8804==    at 0x4C2DB8F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==8804==    by 0x5111718: g_malloc (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.4800.2)
==8804==    by 0x5128922: g_slice_alloc (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.4800.2)
==8804==    by 0x50FA74D: g_hash_table_new_full (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.4800.2)
==8804==    by 0x511B8AA: ??? (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.4800.2)
==8804==    by 0x40104E9: call_init.part.0 (dl-init.c:72)
==8804==    by 0x40105FA: call_init (dl-init.c:30)
==8804==    by 0x40105FA: _dl_init (dl-init.c:120)
==8804==    by 0x4000CF9: ??? (in /lib/x86_64-linux-gnu/ld-2.23.so)
==8804== 
==8804== 88 bytes in 1 blocks are still reachable in loss record 14 of 17
==8804==    at 0x4C2DB8F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==8804==    by 0x5111718: g_malloc (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.4800.2)
==8804==    by 0x5128922: g_slice_alloc (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.4800.2)
==8804==    by 0x50FA74D: g_hash_table_new_full (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.4800.2)
==8804==    by 0x5135762: g_time_zone_new (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.4800.2)
==8804==    by 0x50F413A: g_date_time_new_now_local (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.4800.2)
==8804==    by 0x4EA510C: _generate_date_string (in /usr/local/lib/libds3.so)
==8804==    by 0x4EA61D5: net_process_request (in /usr/local/lib/libds3.so)
==8804==    by 0x4E60CD5: _internal_request_dispatcher (in /usr/local/lib/libds3.so)
==8804==    by 0x4E8D31C: ds3_put_data_policy_spectra_s3_request (in /usr/local/lib/libds3.so)
==8804==    by 0x548D49: configure_for_tests() (test.cpp:91)
==8804==    by 0x564218: BoostTestFixture::BoostTestFixture() (test.cpp:30)
==8804== 
==8804== 2,032 bytes in 1 blocks are still reachable in loss record 15 of 17
==8804==    at 0x4C2FB55: calloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==8804==    by 0x5111770: g_malloc0 (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.4800.2)
==8804==    by 0x5128B8B: g_slice_alloc (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.4800.2)
==8804==    by 0x50FA74D: g_hash_table_new_full (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.4800.2)
==8804==    by 0x511B8AA: ??? (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.4800.2)
==8804==    by 0x40104E9: call_init.part.0 (dl-init.c:72)
==8804==    by 0x40105FA: call_init (dl-init.c:30)
==8804==    by 0x40105FA: _dl_init (dl-init.c:120)
==8804==    by 0x4000CF9: ??? (in /lib/x86_64-linux-gnu/ld-2.23.so)
==8804== 
==8804== 16,384 bytes in 1 blocks are still reachable in loss record 16 of 17
==8804==    at 0x4C2DB8F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==8804==    by 0x5111718: g_malloc (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.4800.2)
==8804==    by 0x511B8BB: ??? (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.4800.2)
==8804==    by 0x40104E9: call_init.part.0 (dl-init.c:72)
==8804==    by 0x40105FA: call_init (dl-init.c:30)
==8804==    by 0x40105FA: _dl_init (dl-init.c:120)
==8804==    by 0x4000CF9: ??? (in /lib/x86_64-linux-gnu/ld-2.23.so)
==8804== 
==8804== 72,704 bytes in 1 blocks are still reachable in loss record 17 of 17
==8804==    at 0x4C2DB8F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==8804==    by 0x545CEFF: ??? (in /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.21)
==8804==    by 0x40104E9: call_init.part.0 (dl-init.c:72)
==8804==    by 0x40105FA: call_init (dl-init.c:30)
==8804==    by 0x40105FA: _dl_init (dl-init.c:120)
==8804==    by 0x4000CF9: ??? (in /lib/x86_64-linux-gnu/ld-2.23.so)
==8804== 
==8804== LEAK SUMMARY:
==8804==    definitely lost: 0 bytes in 0 blocks
==8804==    indirectly lost: 0 bytes in 0 blocks
==8804==      possibly lost: 0 bytes in 0 blocks
==8804==    still reachable: 91,618 bytes in 17 blocks
==8804==         suppressed: 0 bytes in 0 blocks
==8804== 
==8804== For counts of detected and suppressed errors, rerun with: -v
==8804== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
[100%] Built target mem
