### PR TITLE
fix regression wrt ds3_convert_object_list_from_strings

### DIFF
--- a/src/ds3.c
+++ b/src/ds3.c
@@ -359,10 +359,46 @@ ds3_bulk_object_list_response* ds3_convert_object_list(const ds3_contents_respon
     return obj_list;
 }
 
+ds3_bulk_object_list_response* ds3_convert_object_list_from_strings(const char** objects, uint64_t num_objects) {
+    size_t object_index;
+    ds3_bulk_object_list_response* obj_list = ds3_init_bulk_object_list();
+
+    GPtrArray* ds3_bulk_object_response_array = g_ptr_array_new();
+
+    for (object_index = 0; object_index < num_objects; object_index++) {
+        ds3_bulk_object_response* response = g_new0(ds3_bulk_object_response, 1);
+        response->name = ds3_str_init(objects[object_index]);
+        g_ptr_array_add(ds3_bulk_object_response_array, response);
+    }
+
+    obj_list->objects = (ds3_bulk_object_response**)ds3_bulk_object_response_array->pdata;
+    obj_list->num_objects = ds3_bulk_object_response_array->len;
+    g_ptr_array_free(ds3_bulk_object_response_array, FALSE);
+
+    return obj_list;
+}
+
 ds3_bulk_object_list_response* ds3_init_bulk_object_list() {
     return g_new0(ds3_bulk_object_list_response, 1);
 }
 
+ds3_bulk_object_list_response* ds3_init_bulk_object_list_with_size(size_t num_objects) {
+    size_t object_index;
+    ds3_bulk_object_list_response* obj_list = ds3_init_bulk_object_list();
+
+    GPtrArray* ds3_bulk_object_response_array = g_ptr_array_new();
+
+    for (object_index = 0; object_index < num_objects; object_index++) {
+        ds3_bulk_object_response* response = g_new0(ds3_bulk_object_response, 1);
+        g_ptr_array_add(ds3_bulk_object_response_array, response);
+    }
+
+    obj_list->objects = (ds3_bulk_object_response**)ds3_bulk_object_response_array->pdata;
+    obj_list->num_objects = ds3_bulk_object_response_array->len;
+    g_ptr_array_free(ds3_bulk_object_response_array, FALSE);
+
+    return obj_list;
+}
 void ds3_multipart_upload_part_response_free(ds3_multipart_upload_part_response* response) {
     if (response == NULL) {
         return;

--- a/src/ds3.h
+++ b/src/ds3.h
@@ -4998,8 +4998,17 @@ LIBRARY_API size_t ds3_read_from_fd(void* buffer, size_t size, size_t nmemb, voi
 LIBRARY_API ds3_bulk_object_list_response* ds3_convert_file_list(const char** file_list, uint64_t num_files);
 LIBRARY_API ds3_bulk_object_list_response* ds3_convert_file_list_with_basepath(const char** file_list, uint64_t num_files, const char* base_path);
 LIBRARY_API ds3_bulk_object_list_response* ds3_convert_object_list(const ds3_contents_response** objects, uint64_t num_objects);
+LIBRARY_API ds3_bulk_object_list_response* ds3_convert_object_list_from_strings(const char** objects, uint64_t num_objects);
+/*
+ * Init a single ds3_bulk_object_list_response object containing no ds3_bulk_object_response objects
+ */
 LIBRARY_API ds3_bulk_object_list_response* ds3_init_bulk_object_list();
-
+/*
+ * Init a single ds3_bulk_object_list_response object containing num_objects ds3_bulk_object_response objects.
+ *   each ds3_bulk_object_response object will need its properties (name, bucket, etc) to be set with ds3_str_init("name"),
+ *   and physical_placement will be null.
+ */
+LIBRARY_API ds3_bulk_object_list_response* ds3_init_bulk_object_list_with_size(size_t num_objects);
 
 #ifdef __cplusplus
 }

--- a/src/ds3_requests.c
+++ b/src/ds3_requests.c
@@ -407,17 +407,6 @@ static ds3_error* _get_request_xml_nodes(
     return NULL;
 }
 
-static char* _get_ds3_job_chunk_client_processing_order_guarantee_str(ds3_job_chunk_client_processing_order_guarantee input) {
-    if (input == DS3_JOB_CHUNK_CLIENT_PROCESSING_ORDER_GUARANTEE_NONE) {
-        return "NONE";
-    } else if (input == DS3_JOB_CHUNK_CLIENT_PROCESSING_ORDER_GUARANTEE_IN_ORDER) {
-        return "IN_ORDER";
-    } else {
-        return "";
-    }
-
-}
-
 static xmlDocPtr _generate_xml_bulk_objects_list(const ds3_bulk_object_list_response* obj_list, object_list_type list_type, ds3_job_chunk_client_processing_order_guarantee order) {
     char size_buff[UNSIGNED_LONG_LONG_BASE_10_STR_LEN];
     xmlDocPtr doc;


### PR DESCRIPTION
Autogen templates got out of sync from previous commit for utility functions needed by Ruby SDK