### PR TITLE
Print unsigned long long Platform independent

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,8 +9,10 @@ add_library(ds3 SHARED
             ds3_connection.h ds3_connection.c)
 
 if (WIN32)
-    #set(WINDOWS_VS_OUTPUT_DIR ${PROJECT_SOURCE_DIR}/win32/src/Debug)
+    set(CMAKE_BUILD_TYPE Release)
     set(WINDOWS_VS_OUTPUT_DIR ${PROJECT_SOURCE_DIR}/win32/src/Release)
+    #set(CMAKE_BUILD_TYPE Debug)
+    #set(WINDOWS_VS_OUTPUT_DIR ${PROJECT_SOURCE_DIR}/win32/src/Debug)
 
     set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${WINDOWS_VS_OUTPUT_DIR})
     set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${WINDOWS_VS_OUTPUT_DIR})

--- a/src/ds3_init_requests.c
+++ b/src/ds3_init_requests.c
@@ -26,6 +26,15 @@
 #include "ds3_request.h"
 #include "ds3_net.h"
 
+#ifdef _WIN32
+  #include <io.h>
+  #ifndef PRIu64
+    #define PRIu64 "I64u"
+  #endif
+#else
+  #include <inttypes.h>
+#endif
+
 #define STRING_BUFFER_SIZE 32
 
 static char* _get_ds3_bucket_acl_permission_str(ds3_bucket_acl_permission input) {
@@ -854,21 +863,21 @@ static void _set_query_param_flag(const ds3_request* _request, const char* key, 
 static void _set_query_param_uint64_t(const ds3_request* _request, const char* key, uint64_t value) {
     char string_buffer[STRING_BUFFER_SIZE];
     memset(string_buffer, 0, sizeof(string_buffer));
-    snprintf(string_buffer, sizeof(string_buffer), "%" PRIu64, value);
+    g_snprintf(string_buffer, sizeof(string_buffer), "%" PRIu64, value);
     _set_query_param(_request, key, string_buffer);
 }
 
 static void _set_query_param_int(const ds3_request* _request, const char* key, int value) {
     char string_buffer[STRING_BUFFER_SIZE];
     memset(string_buffer, 0, sizeof(string_buffer));
-    snprintf(string_buffer, sizeof(string_buffer), "%d", value);
+    g_snprintf(string_buffer, sizeof(string_buffer), "%d", value);
     _set_query_param(_request, key, string_buffer);
 }
 
 static void _set_query_param_float(const ds3_request* _request, const char* key, float value) {
     char string_buffer[STRING_BUFFER_SIZE];
     memset(string_buffer, 0, sizeof(string_buffer));
-    snprintf(string_buffer, sizeof(string_buffer), "%f", value);
+    g_snprintf(string_buffer, sizeof(string_buffer), "%f", value);
     _set_query_param(_request, key, string_buffer);
 }
 

--- a/src/ds3_init_requests.c
+++ b/src/ds3_init_requests.c
@@ -26,7 +26,7 @@
 #include "ds3_request.h"
 #include "ds3_net.h"
 
-static const unsigned int STRING_BUFFER_SIZE = 32;
+#define STRING_BUFFER_SIZE 32
 
 static char* _get_ds3_bucket_acl_permission_str(ds3_bucket_acl_permission input) {
     if (input == DS3_BUCKET_ACL_PERMISSION_LIST) {

--- a/src/ds3_init_requests.c
+++ b/src/ds3_init_requests.c
@@ -26,12 +26,7 @@
 #include "ds3_request.h"
 #include "ds3_net.h"
 
-//The max size of an uint32_t should be 10 characters + NULL
-static const char UNSIGNED_LONG_BASE_10[] = "4294967296";
-static const unsigned int UNSIGNED_LONG_BASE_10_STR_LEN = sizeof(UNSIGNED_LONG_BASE_10) + 1;
-//The max size of an uint64_t should be 20 characters + NULL
-static const char UNSIGNED_LONG_LONG_BASE_10[] = "18446744073709551615";
-static const unsigned int UNSIGNED_LONG_LONG_BASE_10_STR_LEN = sizeof(UNSIGNED_LONG_LONG_BASE_10) + 1;
+static const unsigned int STRING_BUFFER_SIZE = 32;
 
 static char* _get_ds3_bucket_acl_permission_str(ds3_bucket_acl_permission input) {
     if (input == DS3_BUCKET_ACL_PERMISSION_LIST) {
@@ -857,21 +852,21 @@ static void _set_query_param_flag(const ds3_request* _request, const char* key, 
 }
 
 static void _set_query_param_uint64_t(const ds3_request* _request, const char* key, uint64_t value) {
-    char string_buffer[UNSIGNED_LONG_LONG_BASE_10_STR_LEN];
+    char string_buffer[STRING_BUFFER_SIZE];
     memset(string_buffer, 0, sizeof(string_buffer));
     snprintf(string_buffer, sizeof(string_buffer), "%" PRIu64, value);
     _set_query_param(_request, key, string_buffer);
 }
 
 static void _set_query_param_int(const ds3_request* _request, const char* key, int value) {
-    char string_buffer[UNSIGNED_LONG_BASE_10_STR_LEN];
+    char string_buffer[STRING_BUFFER_SIZE];
     memset(string_buffer, 0, sizeof(string_buffer));
     snprintf(string_buffer, sizeof(string_buffer), "%d", value);
     _set_query_param(_request, key, string_buffer);
 }
 
 static void _set_query_param_float(const ds3_request* _request, const char* key, float value) {
-    char string_buffer[UNSIGNED_LONG_BASE_10_STR_LEN];
+    char string_buffer[STRING_BUFFER_SIZE];
     memset(string_buffer, 0, sizeof(string_buffer));
     snprintf(string_buffer, sizeof(string_buffer), "%f", value);
     _set_query_param(_request, key, string_buffer);

--- a/src/ds3_requests.c
+++ b/src/ds3_requests.c
@@ -28,9 +28,12 @@
 #include "ds3_utils.h"
 
 #ifdef _WIN32
-#include <io.h>
+  #include <io.h>
+  #ifndef PRIu64
+    #define PRIu64 "I64u"
+  #endif
 #else
-#include <inttypes.h>
+  #include <inttypes.h>
 #endif
 
 
@@ -427,6 +430,7 @@ static xmlDocPtr _generate_xml_bulk_objects_list(const ds3_bulk_object_list_resp
 
     for (obj_index = 0; obj_index < obj_list->num_objects; obj_index++) {
         obj = obj_list->objects[obj_index];
+        memset(size_buff, 0, sizeof(size_buff));
         g_snprintf(size_buff, STRING_BUFFER_SIZE, "%" PRIu64, obj->length);
 
         object_node = xmlNewNode(NULL, (xmlChar*) "Object");

--- a/src/ds3_requests.c
+++ b/src/ds3_requests.c
@@ -34,13 +34,9 @@
 #endif
 
 
-//The max size of an uint32_t should be 10 characters + NULL
-static const char UNSIGNED_LONG_BASE_10[] = "4294967296";
-static const unsigned int UNSIGNED_LONG_BASE_10_STR_LEN = sizeof(UNSIGNED_LONG_BASE_10) + 1;
-//The max size of an uint64_t should be 20 characters + NULL
-static const char UNSIGNED_LONG_LONG_BASE_10[] = "18446744073709551615";
-static const unsigned int UNSIGNED_LONG_LONG_BASE_10_STR_LEN = sizeof(UNSIGNED_LONG_LONG_BASE_10) + 1;
-
+//The max size of an uint32_t is 10 characters + NULL
+//The max size of an uint64_t is 20 characters + NULL
+#define STRING_BUFFER_SIZE 32
 
 
 struct _ds3_metadata {
@@ -408,7 +404,7 @@ static ds3_error* _get_request_xml_nodes(
 }
 
 static xmlDocPtr _generate_xml_bulk_objects_list(const ds3_bulk_object_list_response* obj_list, object_list_type list_type, ds3_job_chunk_client_processing_order_guarantee order) {
-    char size_buff[UNSIGNED_LONG_LONG_BASE_10_STR_LEN];
+    char size_buff[STRING_BUFFER_SIZE];
     xmlDocPtr doc;
     ds3_bulk_object_response* obj;
     xmlNodePtr objects_node, object_node;
@@ -431,7 +427,7 @@ static xmlDocPtr _generate_xml_bulk_objects_list(const ds3_bulk_object_list_resp
 
     for (obj_index = 0; obj_index < obj_list->num_objects; obj_index++) {
         obj = obj_list->objects[obj_index];
-        g_snprintf(size_buff, sizeof(char) * UNSIGNED_LONG_LONG_BASE_10_STR_LEN, "%" PRIu64, obj->length);
+        g_snprintf(size_buff, STRING_BUFFER_SIZE, "%" PRIu64, obj->length);
 
         object_node = xmlNewNode(NULL, (xmlChar*) "Object");
         xmlAddChild(objects_node, object_node);
@@ -448,7 +444,7 @@ static xmlDocPtr _generate_xml_bulk_objects_list(const ds3_bulk_object_list_resp
 }
 
 static xmlDocPtr _generate_xml_complete_mpu(const ds3_complete_multipart_upload_response* mpu_list) {
-    char size_buff[UNSIGNED_LONG_LONG_BASE_10_STR_LEN];
+    char size_buff[STRING_BUFFER_SIZE];
     xmlDocPtr doc;
     ds3_multipart_upload_part_response* part;
     xmlNodePtr parts_node, part_node;
@@ -464,7 +460,7 @@ static xmlDocPtr _generate_xml_complete_mpu(const ds3_complete_multipart_upload_
         part_node = xmlNewNode(NULL, (xmlChar*) "Part");
         xmlAddChild(parts_node, part_node);
 
-        g_snprintf(size_buff, sizeof(char) * UNSIGNED_LONG_LONG_BASE_10_STR_LEN, "%d", part->part_number);
+        g_snprintf(size_buff, STRING_BUFFER_SIZE, "%d", part->part_number);
         xmlNewTextChild(part_node, NULL, (xmlChar*) "PartNumber", (xmlChar*) size_buff);
 
         xmlNewTextChild(part_node, NULL, (xmlChar*) "ETag", (xmlChar*) part->etag->value);


### PR DESCRIPTION
Visual Studio is apparently C89 compliant, so a few changes were needed to make printing of uint64_t work correctly.

Added tests to verify we are able to set the max offset size for a put_object request, and fixed a regression in the create folder test where we free'd a struct too early.