### PR TITLE
Fix ds3_connection_pool queue behavior

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ Debug/
 *.pdb
 ds3.dll
 /win32/output/bin
+.idea/
+cmake-build-debug/
+*.dylib

--- a/src/ds3.c
+++ b/src/ds3.c
@@ -25,6 +25,7 @@
 
 #include "ds3.h"
 #include "ds3_net.h"
+#include "ds3_connection.h"
 #include "ds3_request.h"
 #include "ds3_string_multimap_impl.h"
 #include "ds3_utils.h"

--- a/src/ds3_connection.h
+++ b/src/ds3_connection.h
@@ -26,25 +26,16 @@ extern "C" {
 
 #include <curl/curl.h>
 #include <glib.h>
+#include "ds3.h"
 
-#define CONNECTION_POOL_SIZE 10
+#define DEFAULT_CONNECTION_POOL_SIZE 10
 
 typedef GMutex ds3_mutex;
 typedef GCond ds3_condition;
 
 typedef CURL ds3_connection;
 
-//-- Opaque struct
-struct _ds3_connection_pool{
-    ds3_connection** connections;
-    int*             queue;
-    uint16_t         size;
-    int              head;
-    int              tail;
-    ds3_mutex        mutex;
-    ds3_condition    available_connections;
-    uint16_t         ref_count;
-};
+typedef struct _ds3_connection_pool ds3_connection_pool;
 
 ds3_connection_pool* ds3_connection_pool_init(void);
 ds3_connection_pool* ds3_connection_pool_init_with_size(uint16_t pool_size);

--- a/src/ds3_connection.h
+++ b/src/ds3_connection.h
@@ -37,7 +37,8 @@ typedef CURL ds3_connection;
 //-- Opaque struct
 struct _ds3_connection_pool{
     ds3_connection** connections;
-    uint16_t         num_connections;
+    int*             queue;
+    uint16_t         size;
     int              head;
     int              tail;
     ds3_mutex        mutex;

--- a/src/ds3_net.c
+++ b/src/ds3_net.c
@@ -20,10 +20,8 @@
 #include <curl/curl.h>
 
 #include "ds3_request.h"
-#include "ds3.h"
 #include "ds3_net.h"
 #include "ds3_utils.h"
-#include "ds3_string_multimap.h"
 #include "ds3_string_multimap_impl.h"
 #include "ds3_connection.h"
 

--- a/src/ds3_net.h
+++ b/src/ds3_net.h
@@ -26,7 +26,6 @@ extern "C" {
 
 #include "ds3.h"
 #include "ds3_string_multimap.h"
-#include "ds3_connection.h"
 
 char* escape_url(const char* url);
 char* escape_url_extended(const char* url, const char** delimiters, uint32_t num_delimiters);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -64,19 +64,19 @@ else(WIN32) # POSIX
 endif(WIN32)
 
 add_executable(ds3_c_tests
-  #bucket_tests.cpp
-  #bulk_get.cpp
-  #bulk_put.cpp
-  #checksum.cpp
-  #deletes_test.cpp
-  #get_physical_placement.cpp
-  #job_tests.cpp
-  #metadata_tests.cpp
-  #multimap_tests.cpp
-  #negative_tests.cpp
-  #search_tests.cpp
-  #service_tests.cpp
-  #connection_tests.cpp
+  bucket_tests.cpp
+  bulk_get.cpp
+  bulk_put.cpp
+  checksum.cpp
+  deletes_test.cpp
+  get_physical_placement.cpp
+  job_tests.cpp
+  metadata_tests.cpp
+  multimap_tests.cpp
+  negative_tests.cpp
+  search_tests.cpp
+  service_tests.cpp
+  connection_tests.cpp
   put_directory.cpp
   test.cpp)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -64,19 +64,19 @@ else(WIN32) # POSIX
 endif(WIN32)
 
 add_executable(ds3_c_tests
-  bucket_tests.cpp
-  bulk_get.cpp
-  bulk_put.cpp
-  checksum.cpp
-  deletes_test.cpp
-  get_physical_placement.cpp
-  job_tests.cpp
-  metadata_tests.cpp
-  multimap_tests.cpp
-  negative_tests.cpp
-  search_tests.cpp
-  service_tests.cpp
-  connection_tests.cpp
+  #bucket_tests.cpp
+  #bulk_get.cpp
+  #bulk_put.cpp
+  #checksum.cpp
+  #deletes_test.cpp
+  #get_physical_placement.cpp
+  #job_tests.cpp
+  #metadata_tests.cpp
+  #multimap_tests.cpp
+  #negative_tests.cpp
+  #search_tests.cpp
+  #service_tests.cpp
+  #connection_tests.cpp
   put_directory.cpp
   test.cpp)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -77,6 +77,7 @@ add_executable(ds3_c_tests
   search_tests.cpp
   service_tests.cpp
   connection_tests.cpp
+  put_directory.cpp
   test.cpp)
 
 add_test(regression_tests ds3_c_tests)

--- a/test/put_directory.cpp
+++ b/test/put_directory.cpp
@@ -103,7 +103,7 @@ BOOST_AUTO_TEST_CASE( put_directory_4_threads) {
     const char* bucket_name = "test_bulk_put_directory";
     printf("  Putting all files in [%s] to bucket [%s]\n", dir_path, bucket_name);
 
-    ds3_client* client = get_client();
+    ds3_client* client = get_client_at_loglvl(DS3_DEBUG);
     int client_thread=1;
     ds3_client_register_logging(client, DS3_DEBUG, test_log, (void*)&client_thread); // Use DEBUG level logging
 
@@ -139,10 +139,10 @@ BOOST_AUTO_TEST_CASE( put_directory_4_threads) {
     double elapsed_t;
     clock_gettime(CLOCK_MONOTONIC, &start_time_t);
 
-    GThread* put_dir_xfer_thread_0 = g_thread_new("put_dir_xfer_thread_1", (GThreadFunc)put_chunks_from_file, g_ptr_array_index(put_dir_args, 0));
-    GThread* put_dir_xfer_thread_1 = g_thread_new("put_dir_xfer_thread_2", (GThreadFunc)put_chunks_from_file, g_ptr_array_index(put_dir_args, 1));
-    GThread* put_dir_xfer_thread_2 = g_thread_new("put_dir_xfer_thread_3", (GThreadFunc)put_chunks_from_file, g_ptr_array_index(put_dir_args, 2));
-    GThread* put_dir_xfer_thread_3 = g_thread_new("put_dir_xfer_thread_4", (GThreadFunc)put_chunks_from_file, g_ptr_array_index(put_dir_args, 3));
+    GThread* put_dir_xfer_thread_0 = g_thread_new("put_dir_xfer_thread_0", (GThreadFunc)put_chunks_from_file, g_ptr_array_index(put_dir_args, 0));
+    GThread* put_dir_xfer_thread_1 = g_thread_new("put_dir_xfer_thread_1", (GThreadFunc)put_chunks_from_file, g_ptr_array_index(put_dir_args, 1));
+    GThread* put_dir_xfer_thread_2 = g_thread_new("put_dir_xfer_thread_2", (GThreadFunc)put_chunks_from_file, g_ptr_array_index(put_dir_args, 2));
+    GThread* put_dir_xfer_thread_3 = g_thread_new("put_dir_xfer_thread_3", (GThreadFunc)put_chunks_from_file, g_ptr_array_index(put_dir_args, 3));
 
     // Block and cleanup GThread(s)
     g_thread_join(put_dir_xfer_thread_0);

--- a/test/put_directory.cpp
+++ b/test/put_directory.cpp
@@ -1,0 +1,91 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2016 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <glib.h>
+#include <sys/stat.h>
+#include <boost/test/unit_test.hpp>
+#include <inttypes.h>
+#include "ds3.h"
+#include "ds3_net.h"
+#include "test.h"
+
+struct check_ds3_test_directory_given {
+    return getenv(DS3_TEST_DIRECTORY) != NULL;
+};
+
+BOOST_AUTO_TEST_CASE( put_directory,
+                      * boost::unit_test::precondition(check_ds3_test_directory_given)) {
+    printf("-----Testing PUT all objects in a directory-------\n");
+
+    const char* dir_path = getenv("DS3_TEST_DIRECTORY");
+    BOOST_CHECK(dir_path != NULL);
+
+    const char* bucket_name = "test_bulk_put_directory";
+
+    ds3_request* request = NULL;
+    ds3_master_object_list_response* bulk_response = NULL;
+
+    ds3_client* client = get_client();
+    int client_thread=1;
+    ds3_client_register_logging(client, DS3_DEBUG, test_log, (void*)&client_thread); // Use DEBUG level logging
+
+    ds3_error* error = create_bucket_with_data_policy(client, bucket_name, ids.data_policy_id->value);
+
+    char** objects_list;
+    uint64_t num_objs = 0;
+    GDir* dir_info = g_dir_open(dir_path, 0, NULL);
+    for (char* current_obj = (char*)g_dir_read_name(dir_info); current_obj != NULL; current_obj = (char*)g_dir_read_name(dir_info)) {
+        objects_list[num_objs++] = current_obj;
+    }
+
+    ds3_bulk_object_list_response* bulk_object_list = ds3_convert_object_list_from_strings((const char**)objects_list, num_objs);
+
+    request = ds3_init_put_bulk_job_spectra_s3_request(bucket_name, bulk_object_list);
+    ds3_master_object_list_response* mol;
+    error = ds3_put_bulk_job_spectra_s3_request(client, request, &mol);
+    ds3_request_free(request);
+    ds3_bulk_object_list_response_free(bulk_object_list);
+    handle_error(error);
+
+    ds3_master_object_list_response* chunks_list = ensure_available_chunks(client, mol->job_id);
+
+    // Use helper functions from test.cpp
+    GPtrArray* put_dir_args = new_put_chunks_threads_args(client, NULL, bucket_name, mol, chunks_list, 1, True); // Last param indicates verbose logging in the spawned thread
+
+    // capture test start time
+    struct timespec start_time_t, end_time_t;
+    double elapsed_t;
+    clock_gettime(CLOCK_MONOTONIC, &start_time_t);
+
+    GThread* put_dir_xfer_thread = g_thread_new("put_dir_xfer_thread", (GThreadFunc)put_chunks_from_file, g_ptr_array_index(put_dir_args, 0));
+
+    // Block and cleanup GThread(s)
+    g_thread_join(put_dir_xfer_thread);
+
+    // find elapsed CPU and real time
+    clock_gettime(CLOCK_MONOTONIC, &end_time_t);
+    elapsed_t = timespec_to_seconds(&end_time_t) - timespec_to_seconds(&start_time_t);
+    ds3_log_message(client1->log, DS3_INFO, "  Elapsed time[%f]", elapsed_t);
+
+    ds3_master_object_list_response_free(chunks_list);
+    ds3_master_object_list_response_free(mol);
+    put_chunks_threads_args_free(put_dir_args);
+    clear_bucket(client, bucket_name);
+    free_client(client);
+}
+

--- a/test/put_directory.cpp
+++ b/test/put_directory.cpp
@@ -25,18 +25,15 @@
 #include "ds3_utils.h"
 #include "test.h"
 
-namespace utf = boost::unit_test;
-
-bool check_ds3_test_directory_given() {
-    return getenv("DS3_TEST_DIRECTORY") != NULL;
-};
-
+/*
 BOOST_AUTO_TEST_CASE( put_directory) {
-                      //* boost::unit_test::precondition(check_ds3_test_directory_given)) {
     printf("-----Testing PUT all objects in a directory-------\n");
 
     const char* dir_path = getenv("DS3_TEST_DIRECTORY");
-    BOOST_CHECK(dir_path != NULL);
+    if (dir_path == NULL) {
+        printf("ENV[DS3_TEST_DIRECTORY] unset - Skipping put_directory test.\n");
+        return;
+    }
 
     const char* bucket_name = "test_bulk_put_directory";
     printf("  Putting all files in [%s] to bucket [%s]\n", dir_path, bucket_name);
@@ -92,4 +89,76 @@ BOOST_AUTO_TEST_CASE( put_directory) {
     clear_bucket(client, bucket_name);
     free_client(client);
 }
+*/
 
+BOOST_AUTO_TEST_CASE( put_directory_4_threads) {
+    printf("-----Testing PUT all objects in a directory with 4 threads-------\n");
+
+    const char* dir_path = getenv("DS3_TEST_DIRECTORY");
+    if (dir_path == NULL) {
+        printf("ENV[DS3_TEST_DIRECTORY] unset - Skipping put_directory test.\n");
+        return;
+    }
+
+    const char* bucket_name = "test_bulk_put_directory";
+    printf("  Putting all files in [%s] to bucket [%s]\n", dir_path, bucket_name);
+
+    ds3_client* client = get_client();
+    int client_thread=1;
+    ds3_client_register_logging(client, DS3_DEBUG, test_log, (void*)&client_thread); // Use DEBUG level logging
+
+    ds3_error* error = create_bucket_with_data_policy(client, bucket_name, ids.data_policy_id->value);
+
+    char* objects_list[100];
+    uint64_t num_objs = 0;
+    GDir* dir_info = g_dir_open(dir_path, 0, NULL);
+    for (char* current_obj = (char*)g_dir_read_name(dir_info); current_obj != NULL; current_obj = (char*)g_dir_read_name(dir_info)) {
+        objects_list[num_objs++] = current_obj;
+        printf("  obj[%" PRIu64 "][%s]\n", num_objs, objects_list[num_objs-1]);
+    }
+
+    ds3_bulk_object_list_response* bulk_object_list = ds3_convert_file_list_with_basepath((const char**)objects_list, num_objs, dir_path);
+
+    ds3_request* request = ds3_init_put_bulk_job_spectra_s3_request(bucket_name, bulk_object_list);
+    ds3_master_object_list_response* mol;
+    error = ds3_put_bulk_job_spectra_s3_request(client, request, &mol);
+    ds3_request_free(request);
+    ds3_bulk_object_list_response_free(bulk_object_list);
+    handle_error(error);
+
+    // Allocate cache
+    ds3_master_object_list_response* chunks_list = ensure_available_chunks(client, mol->job_id);
+
+    // Use helper functions from test.cpp
+    const uint8_t num_threads = 4;
+    GPtrArray* put_dir_args = new_put_chunks_threads_args(client, NULL, dir_path, bucket_name, mol, chunks_list, num_threads, True); // Last param indicates verbose logging in the spawned thread
+
+
+    // capture test start time
+    struct timespec start_time_t, end_time_t;
+    double elapsed_t;
+    clock_gettime(CLOCK_MONOTONIC, &start_time_t);
+
+    GThread* put_dir_xfer_thread_0 = g_thread_new("put_dir_xfer_thread_1", (GThreadFunc)put_chunks_from_file, g_ptr_array_index(put_dir_args, 0));
+    GThread* put_dir_xfer_thread_1 = g_thread_new("put_dir_xfer_thread_2", (GThreadFunc)put_chunks_from_file, g_ptr_array_index(put_dir_args, 1));
+    GThread* put_dir_xfer_thread_2 = g_thread_new("put_dir_xfer_thread_3", (GThreadFunc)put_chunks_from_file, g_ptr_array_index(put_dir_args, 2));
+    GThread* put_dir_xfer_thread_3 = g_thread_new("put_dir_xfer_thread_4", (GThreadFunc)put_chunks_from_file, g_ptr_array_index(put_dir_args, 3));
+
+    // Block and cleanup GThread(s)
+    g_thread_join(put_dir_xfer_thread_0);
+    g_thread_join(put_dir_xfer_thread_1);
+    g_thread_join(put_dir_xfer_thread_2);
+    g_thread_join(put_dir_xfer_thread_3);
+
+    // find elapsed CPU and real time
+    clock_gettime(CLOCK_MONOTONIC, &end_time_t);
+    elapsed_t = timespec_to_seconds(&end_time_t) - timespec_to_seconds(&start_time_t);
+    ds3_log_message(client->log, DS3_INFO, "  Elapsed time[%f]", elapsed_t);
+
+    g_dir_close(dir_info);
+    ds3_master_object_list_response_free(chunks_list);
+    ds3_master_object_list_response_free(mol);
+    put_chunks_threads_args_free(put_dir_args);
+    clear_bucket(client, bucket_name);
+    free_client(client);
+}

--- a/test/put_directory.cpp
+++ b/test/put_directory.cpp
@@ -25,78 +25,12 @@
 #include "ds3_utils.h"
 #include "test.h"
 
-/*
-BOOST_AUTO_TEST_CASE( put_directory) {
-    printf("-----Testing PUT all objects in a directory-------\n");
-
-    const char* dir_path = getenv("DS3_TEST_DIRECTORY");
-    if (dir_path == NULL) {
-        printf("ENV[DS3_TEST_DIRECTORY] unset - Skipping put_directory test.\n");
-        return;
-    }
-
-    const char* bucket_name = "test_bulk_put_directory";
-    printf("  Putting all files in [%s] to bucket [%s]\n", dir_path, bucket_name);
-
-    ds3_client* client = get_client();
-    int client_thread=1;
-    ds3_client_register_logging(client, DS3_DEBUG, test_log, (void*)&client_thread); // Use DEBUG level logging
-
-    ds3_error* error = create_bucket_with_data_policy(client, bucket_name, ids.data_policy_id->value);
-
-    char* objects_list[100];
-    uint64_t num_objs = 0;
-    GDir* dir_info = g_dir_open(dir_path, 0, NULL);
-    for (char* current_obj = (char*)g_dir_read_name(dir_info); current_obj != NULL; current_obj = (char*)g_dir_read_name(dir_info)) {
-        objects_list[num_objs++] = current_obj;
-        printf("  obj[%" PRIu64 "][%s]\n", num_objs, objects_list[num_objs-1]);
-    }
-
-    ds3_bulk_object_list_response* bulk_object_list = ds3_convert_file_list_with_basepath((const char**)objects_list, num_objs, dir_path);
-
-    ds3_request* request = ds3_init_put_bulk_job_spectra_s3_request(bucket_name, bulk_object_list);
-    ds3_master_object_list_response* mol;
-    error = ds3_put_bulk_job_spectra_s3_request(client, request, &mol);
-    ds3_request_free(request);
-    ds3_bulk_object_list_response_free(bulk_object_list);
-    handle_error(error);
-
-    // Allocate cache
-    ds3_master_object_list_response* chunks_list = ensure_available_chunks(client, mol->job_id);
-
-    // Use helper functions from test.cpp
-    GPtrArray* put_dir_args = new_put_chunks_threads_args(client, NULL, dir_path, bucket_name, mol, chunks_list, 1, True); // Last param indicates verbose logging in the spawned thread
-
-    // capture test start time
-    struct timespec start_time_t, end_time_t;
-    double elapsed_t;
-    clock_gettime(CLOCK_MONOTONIC, &start_time_t);
-
-    GThread* put_dir_xfer_thread = g_thread_new("put_dir_xfer_thread", (GThreadFunc)put_chunks_from_file, g_ptr_array_index(put_dir_args, 0));
-
-    // Block and cleanup GThread(s)
-    g_thread_join(put_dir_xfer_thread);
-
-    // find elapsed CPU and real time
-    clock_gettime(CLOCK_MONOTONIC, &end_time_t);
-    elapsed_t = timespec_to_seconds(&end_time_t) - timespec_to_seconds(&start_time_t);
-    ds3_log_message(client->log, DS3_INFO, "  Elapsed time[%f]", elapsed_t);
-
-    g_dir_close(dir_info);
-    ds3_master_object_list_response_free(chunks_list);
-    ds3_master_object_list_response_free(mol);
-    put_chunks_threads_args_free(put_dir_args);
-    clear_bucket(client, bucket_name);
-    free_client(client);
-}
-*/
-
 BOOST_AUTO_TEST_CASE( put_directory_4_threads) {
     printf("-----Testing PUT all objects in a directory with 4 threads-------\n");
 
     const char* dir_path = getenv("DS3_TEST_DIRECTORY");
     if (dir_path == NULL) {
-        printf("ENV[DS3_TEST_DIRECTORY] unset - Skipping put_directory test.\n");
+        printf("ENV[DS3_TEST_DIRECTORY] unset - Skipping put_directory_4_threads test.\n");
         return;
     }
 

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -45,12 +45,20 @@ struct BoostTestFixture {
 
 BOOST_GLOBAL_FIXTURE( BoostTestFixture );
 
+void log_timestamp(char* string_buff, long buff_size)
+{
+    
+    g_snprintf(string_buff, buff_size, "%s", );
+}
+
 void test_log(const char* message, void* user_data) {
+    char timebuffer[32];
+    log_timestamp(timebuffer, 32);
     if (user_data) {
         int client_num = *((int*)user_data);
-        fprintf(stderr, "ClientNum[%d], Log Message: %s\n", client_num, message);
+        fprintf(stderr, "%s Client[%d] %s\n", client_num, message);
     } else {
-        fprintf(stderr, "Log Message: %s\n", message);
+        fprintf(stderr, "%s %s\n", message);
     }
 }
 
@@ -541,6 +549,9 @@ void put_chunks_from_file(void* args) {
                     char* file_with_path = g_strconcat(_args->src_dir, object->name->value, (char*)NULL);
                     printf("  opening file[%s]\n", file_with_path);
                     file = fopen(file_with_path, "r");
+                    if (file == NULL) {
+                        printf("  ***Unable to open file[%s]!!!\n", file_with_path);
+                    }
                     g_free(file_with_path);
                 }
                 if (object->offset != 0) {

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -47,8 +47,21 @@ BOOST_GLOBAL_FIXTURE( BoostTestFixture );
 
 void log_timestamp(char* string_buff, long buff_size)
 {
-    
-    g_snprintf(string_buff, buff_size, "%s", );
+    time_t ltime;
+    struct tm result;
+    struct timeval tv;
+    char   usec_buff[8];
+
+    gettimeofday(&tv, NULL);
+    millisec = lrint(tv.tv_usec/1000.0); // Round to nearest millisec
+
+    ltime = time(NULL);
+    localtime_r(&ltime, &result);
+
+    strftime(string_buff, buff_size, "%Y:%m:%dT%H:%M:%S", tm);
+    strcat(string_buff, ".");
+    sprintf(usec_buff,"%d", (int)tmnow.tv_usec);
+    strcat(string_buff, usec_buff);
 }
 
 void test_log(const char* message, void* user_data) {
@@ -56,9 +69,9 @@ void test_log(const char* message, void* user_data) {
     log_timestamp(timebuffer, 32);
     if (user_data) {
         int client_num = *((int*)user_data);
-        fprintf(stderr, "%s Client[%d] %s\n", client_num, message);
+        fprintf(stderr, "%s Client[%d] %s\n", timebuffer, client_num, message);
     } else {
-        fprintf(stderr, "%s %s\n", message);
+        fprintf(stderr, "%s %s\n", timebuffer, message);
     }
 }
 

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -45,12 +45,13 @@ struct BoostTestFixture {
 
 BOOST_GLOBAL_FIXTURE( BoostTestFixture );
 
-void log_timestamp(char* string_buff, long buff_size)
+static void _log_timestamp(char* string_buff, long buff_size)
 {
     time_t ltime;
     struct tm result;
     struct timeval tv;
     char   usec_buff[8];
+    int    millisec;
 
     gettimeofday(&tv, NULL);
     millisec = lrint(tv.tv_usec/1000.0); // Round to nearest millisec
@@ -58,15 +59,15 @@ void log_timestamp(char* string_buff, long buff_size)
     ltime = time(NULL);
     localtime_r(&ltime, &result);
 
-    strftime(string_buff, buff_size, "%Y:%m:%dT%H:%M:%S", tm);
+    strftime(string_buff, buff_size, "%Y:%m:%dT%H:%M:%S", &result);
     strcat(string_buff, ".");
-    sprintf(usec_buff,"%d", (int)tmnow.tv_usec);
+    sprintf(usec_buff,"%03d", millisec);
     strcat(string_buff, usec_buff);
 }
 
 void test_log(const char* message, void* user_data) {
     char timebuffer[32];
-    log_timestamp(timebuffer, 32);
+    _log_timestamp(timebuffer, 32);
     if (user_data) {
         int client_num = *((int*)user_data);
         fprintf(stderr, "%s Client[%d] %s\n", timebuffer, client_num, message);

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -525,7 +525,11 @@ void put_chunks_from_file(void* args) {
                 if (_args->verbose) {
                     ds3_log_message(_args->client->log, DS3_INFO, "  GlibThread[%d] BEGIN xfer File[%s] Chunk[%lu]", _args->thread_num, object->name->value, _args->chunks_list->num_objects);
                 }
-                file = fopen(_args->src_object_name, "r");
+                if (_args->src_object_name) {
+                    file = fopen(_args->src_object_name, "r");
+                } else {
+                    file = fopen(object->name->value, "r");
+                }
                 if (object->offset != 0) {
                     fseek(file, object->offset, SEEK_SET);
                 }

--- a/test/test.h
+++ b/test/test.h
@@ -93,6 +93,7 @@ typedef struct {
     ds3_client*                          client;
     char*                                job_id;
     char*                                src_object_name;
+    char*                                src_dir;
     char*                                bucket_name;
     ds3_master_object_list_response*     chunks_list;
     ds3_bool                             verbose;
@@ -107,6 +108,7 @@ void test_log(const char* message, void* user_data);
  */
 GPtrArray* new_put_chunks_threads_args(ds3_client* client,
                                        const char* src_obj_name,
+                                       const char* src_dir,
                                        const char* dest_bucket_name,
                                        const ds3_master_object_list_response* bulk_response,
                                        ds3_master_object_list_response* available_chunks,


### PR DESCRIPTION
Separate the ds3_connection* list from the queue of available connections.

Also add a timestamp with millisecond precision to the test_log() method.