### PR TITLE
Updated tape type to be string instead of enum

### DIFF
--- a/src/ds3.c
+++ b/src/ds3.c
@@ -772,6 +772,7 @@ void ds3_storage_domain_member_response_free(ds3_storage_domain_member_response*
     ds3_str_free(response->pool_partition_id);
     ds3_str_free(response->storage_domain_id);
     ds3_str_free(response->tape_partition_id);
+    ds3_str_free(response->tape_type);
 
     g_free(response);
 }
@@ -1110,6 +1111,7 @@ void ds3_tape_response_free(ds3_tape_response* response) {
     ds3_str_free(response->partition_id);
     ds3_str_free(response->serial_number);
     ds3_str_free(response->storage_domain_id);
+    ds3_str_free(response->type);
 
     g_free(response);
 }
@@ -1120,6 +1122,7 @@ void ds3_tape_density_directive_response_free(ds3_tape_density_directive_respons
 
     ds3_str_free(response->id);
     ds3_str_free(response->partition_id);
+    ds3_str_free(response->tape_type);
 
     g_free(response);
 }
@@ -1628,6 +1631,7 @@ void ds3_detailed_tape_partition_response_free(ds3_detailed_tape_partition_respo
         return;
     }
 
+    size_t index;
     g_free(response->drive_types);
     ds3_str_free(response->error_message);
     ds3_str_free(response->id);
@@ -1635,6 +1639,9 @@ void ds3_detailed_tape_partition_response_free(ds3_detailed_tape_partition_respo
     ds3_str_free(response->name);
     ds3_str_free(response->serial_id);
     ds3_str_free(response->serial_number);
+    for (index = 0; index < response->num_tape_types; index++) {
+        ds3_str_free(response->tape_types[index]);
+    }
     g_free(response->tape_types);
 
     g_free(response);
@@ -1725,6 +1732,7 @@ void ds3_named_detailed_tape_partition_response_free(ds3_named_detailed_tape_par
         return;
     }
 
+    size_t index;
     g_free(response->drive_types);
     ds3_str_free(response->error_message);
     ds3_str_free(response->id);
@@ -1732,6 +1740,9 @@ void ds3_named_detailed_tape_partition_response_free(ds3_named_detailed_tape_par
     ds3_str_free(response->name);
     ds3_str_free(response->serial_id);
     ds3_str_free(response->serial_number);
+    for (index = 0; index < response->num_tape_types; index++) {
+        ds3_str_free(response->tape_types[index]);
+    }
     g_free(response->tape_types);
 
     g_free(response);

--- a/src/ds3.h
+++ b/src/ds3.h
@@ -879,7 +879,7 @@ typedef struct {
     ds3_storage_domain_member_state state;
     ds3_str* storage_domain_id;
     ds3_str* tape_partition_id;
-    ds3_tape_type tape_type;
+    ds3_str* tape_type;
     ds3_write_preference_level write_preference;
 }ds3_storage_domain_member_response;
 typedef struct {
@@ -1176,7 +1176,7 @@ typedef struct {
     ds3_str* storage_domain_id;
     ds3_bool take_ownership_pending;
     uint64_t total_raw_capacity;
-    ds3_tape_type type;
+    ds3_str* type;
     ds3_priority verify_pending;
     ds3_bool write_protected;
 }ds3_tape_response;
@@ -1184,7 +1184,7 @@ typedef struct {
     ds3_tape_drive_type density;
     ds3_str* id;
     ds3_str* partition_id;
-    ds3_tape_type tape_type;
+    ds3_str* tape_type;
 }ds3_tape_density_directive_response;
 typedef struct {
     ds3_bool cleaning_required;
@@ -1499,7 +1499,7 @@ typedef struct {
     ds3_str* serial_id;
     ds3_str* serial_number;
     ds3_tape_partition_state state;
-    ds3_tape_type* tape_types;
+    ds3_str** tape_types;
     size_t num_tape_types;
 }ds3_detailed_tape_partition_response;
 typedef struct {
@@ -1557,7 +1557,7 @@ typedef struct {
     ds3_str* serial_id;
     ds3_str* serial_number;
     ds3_tape_partition_state state;
-    ds3_tape_type* tape_types;
+    ds3_str** tape_types;
     size_t num_tape_types;
 }ds3_named_detailed_tape_partition_response;
 typedef struct {
@@ -2514,7 +2514,7 @@ LIBRARY_API void ds3_request_set_tape_drive_id(const ds3_request* request, const
 LIBRARY_API void ds3_request_set_tape_id(const ds3_request* request, const char * const value);
 LIBRARY_API void ds3_request_set_tape_partition_id(const ds3_request* request, const char * const value);
 LIBRARY_API void ds3_request_set_tape_state_ds3_tape_state(const ds3_request* request, const ds3_tape_state value);
-LIBRARY_API void ds3_request_set_tape_type_ds3_tape_type(const ds3_request* request, const ds3_tape_type value);
+LIBRARY_API void ds3_request_set_tape_type(const ds3_request* request, const char * const value);
 LIBRARY_API void ds3_request_set_target_data_policy(const ds3_request* request, const char * const value);
 LIBRARY_API void ds3_request_set_target_id(const ds3_request* request, const char * const value);
 LIBRARY_API void ds3_request_set_task_priority_ds3_priority(const ds3_request* request, const ds3_priority value);
@@ -2529,7 +2529,7 @@ LIBRARY_API void ds3_request_set_type_ds3_system_failure_type(const ds3_request*
 LIBRARY_API void ds3_request_set_type_ds3_tape_drive_type(const ds3_request* request, const ds3_tape_drive_type value);
 LIBRARY_API void ds3_request_set_type_ds3_tape_failure_type(const ds3_request* request, const ds3_tape_failure_type value);
 LIBRARY_API void ds3_request_set_type_ds3_tape_partition_failure_type(const ds3_request* request, const ds3_tape_partition_failure_type value);
-LIBRARY_API void ds3_request_set_type_ds3_tape_type(const ds3_request* request, const ds3_tape_type value);
+LIBRARY_API void ds3_request_set_type(const ds3_request* request, const char * const value);
 LIBRARY_API void ds3_request_set_type_ds3_target_failure_type(const ds3_request* request, const ds3_target_failure_type value);
 LIBRARY_API void ds3_request_set_unavailable_media_policy_ds3_unavailable_media_usage_policy(const ds3_request* request, const ds3_unavailable_media_usage_policy value);
 LIBRARY_API void ds3_request_set_unavailable_pool_max_job_retry_in_mins(const ds3_request* request, const int value);
@@ -2767,7 +2767,7 @@ LIBRARY_API ds3_error* ds3_modify_cache_filesystem_spectra_s3_request(const ds3_
  *   void ds3_request_set_pool_state_ds3_pool_state(const ds3_request* request, const ds3_pool_state value)
  *   void ds3_request_set_pool_type_ds3_pool_type(const ds3_request* request, const ds3_pool_type value)
  *   void ds3_request_set_tape_state_ds3_tape_state(const ds3_request* request, const ds3_tape_state value)
- *   void ds3_request_set_tape_type_ds3_tape_type(const ds3_request* request, const ds3_tape_type value)
+ *   void ds3_request_set_tape_type(const ds3_request* request, const char * const value)
  */
 LIBRARY_API ds3_request* ds3_init_get_bucket_capacity_summary_spectra_s3_request(const char* bucket_id, const char* storage_domain_id);
 LIBRARY_API ds3_error* ds3_get_bucket_capacity_summary_spectra_s3_request(const ds3_client* client, const ds3_request* request, ds3_capacity_summary_container_response** response);
@@ -2778,7 +2778,7 @@ LIBRARY_API ds3_error* ds3_get_bucket_capacity_summary_spectra_s3_request(const 
  *   void ds3_request_set_pool_state_ds3_pool_state(const ds3_request* request, const ds3_pool_state value)
  *   void ds3_request_set_pool_type_ds3_pool_type(const ds3_request* request, const ds3_pool_type value)
  *   void ds3_request_set_tape_state_ds3_tape_state(const ds3_request* request, const ds3_tape_state value)
- *   void ds3_request_set_tape_type_ds3_tape_type(const ds3_request* request, const ds3_tape_type value)
+ *   void ds3_request_set_tape_type(const ds3_request* request, const char * const value)
  */
 LIBRARY_API ds3_request* ds3_init_get_storage_domain_capacity_summary_spectra_s3_request(const char* storage_domain_id);
 LIBRARY_API ds3_error* ds3_get_storage_domain_capacity_summary_spectra_s3_request(const ds3_client* client, const ds3_request* request, ds3_capacity_summary_container_response** response);
@@ -2789,7 +2789,7 @@ LIBRARY_API ds3_error* ds3_get_storage_domain_capacity_summary_spectra_s3_reques
  *   void ds3_request_set_pool_state_ds3_pool_state(const ds3_request* request, const ds3_pool_state value)
  *   void ds3_request_set_pool_type_ds3_pool_type(const ds3_request* request, const ds3_pool_type value)
  *   void ds3_request_set_tape_state_ds3_tape_state(const ds3_request* request, const ds3_tape_state value)
- *   void ds3_request_set_tape_type_ds3_tape_type(const ds3_request* request, const ds3_tape_type value)
+ *   void ds3_request_set_tape_type(const ds3_request* request, const char * const value)
  */
 LIBRARY_API ds3_request* ds3_init_get_system_capacity_summary_spectra_s3_request(void);
 LIBRARY_API ds3_error* ds3_get_system_capacity_summary_spectra_s3_request(const ds3_client* client, const ds3_request* request, ds3_capacity_summary_container_response** response);
@@ -4123,7 +4123,7 @@ LIBRARY_API ds3_error* ds3_put_storage_domain_spectra_s3_request(const ds3_clien
  *
  *   void ds3_request_set_write_preference_ds3_write_preference_level(const ds3_request* request, const ds3_write_preference_level value)
  */
-LIBRARY_API ds3_request* ds3_init_put_tape_storage_domain_member_spectra_s3_request(const char* storage_domain_id, const char* tape_partition_id, const ds3_tape_type tape_type);
+LIBRARY_API ds3_request* ds3_init_put_tape_storage_domain_member_spectra_s3_request(const char* storage_domain_id, const char* tape_partition_id, const char* tape_type);
 LIBRARY_API ds3_error* ds3_put_tape_storage_domain_member_spectra_s3_request(const ds3_client* client, const ds3_request* request, ds3_storage_domain_member_response** response);
 LIBRARY_API ds3_request* ds3_init_delete_storage_domain_failure_spectra_s3_request(const char *const resource_id);
 LIBRARY_API ds3_error* ds3_delete_storage_domain_failure_spectra_s3_request(const ds3_client* client, const ds3_request* request);
@@ -4157,7 +4157,7 @@ LIBRARY_API ds3_error* ds3_get_storage_domain_member_spectra_s3_request(const ds
  *   void ds3_request_set_state_ds3_storage_domain_member_state(const ds3_request* request, const ds3_storage_domain_member_state value)
  *   void ds3_request_set_storage_domain_id(const ds3_request* request, const char * const value)
  *   void ds3_request_set_tape_partition_id(const ds3_request* request, const char * const value)
- *   void ds3_request_set_tape_type_ds3_tape_type(const ds3_request* request, const ds3_tape_type value)
+ *   void ds3_request_set_tape_type(const ds3_request* request, const char * const value)
  *   void ds3_request_set_write_preference_ds3_write_preference_level(const ds3_request* request, const ds3_write_preference_level value)
  */
 LIBRARY_API ds3_request* ds3_init_get_storage_domain_members_spectra_s3_request(void);
@@ -4263,7 +4263,7 @@ LIBRARY_API ds3_request* ds3_init_cancel_verify_tape_spectra_s3_request(const ch
 LIBRARY_API ds3_error* ds3_cancel_verify_tape_spectra_s3_request(const ds3_client* client, const ds3_request* request, ds3_tape_response** response);
 LIBRARY_API ds3_request* ds3_init_clean_tape_drive_spectra_s3_request(const char *const resource_id);
 LIBRARY_API ds3_error* ds3_clean_tape_drive_spectra_s3_request(const ds3_client* client, const ds3_request* request, ds3_tape_drive_response** response);
-LIBRARY_API ds3_request* ds3_init_put_tape_density_directive_spectra_s3_request(const ds3_tape_drive_type density, const char* partition_id, const ds3_tape_type tape_type);
+LIBRARY_API ds3_request* ds3_init_put_tape_density_directive_spectra_s3_request(const ds3_tape_drive_type density, const char* partition_id, const char* tape_type);
 LIBRARY_API ds3_error* ds3_put_tape_density_directive_spectra_s3_request(const ds3_client* client, const ds3_request* request, ds3_tape_density_directive_response** response);
 LIBRARY_API ds3_request* ds3_init_delete_permanently_lost_tape_spectra_s3_request(const char *const resource_id);
 LIBRARY_API ds3_error* ds3_delete_permanently_lost_tape_spectra_s3_request(const ds3_client* client, const ds3_request* request);
@@ -4339,7 +4339,7 @@ LIBRARY_API ds3_error* ds3_get_tape_density_directive_spectra_s3_request(const d
  *   void ds3_request_set_page_offset(const ds3_request* request, const int value)
  *   void ds3_request_set_page_start_marker(const ds3_request* request, const char * const value)
  *   void ds3_request_set_partition_id(const ds3_request* request, const char * const value)
- *   void ds3_request_set_tape_type_ds3_tape_type(const ds3_request* request, const ds3_tape_type value)
+ *   void ds3_request_set_tape_type(const ds3_request* request, const char * const value)
  */
 LIBRARY_API ds3_request* ds3_init_get_tape_density_directives_spectra_s3_request(void);
 LIBRARY_API ds3_error* ds3_get_tape_density_directives_spectra_s3_request(const ds3_client* client, const ds3_request* request, ds3_tape_density_directive_list_response** response);
@@ -4461,7 +4461,7 @@ LIBRARY_API ds3_error* ds3_get_tape_spectra_s3_request(const ds3_client* client,
  *   void ds3_request_set_sort_by(const ds3_request* request, const char * const value)
  *   void ds3_request_set_state_ds3_tape_state(const ds3_request* request, const ds3_tape_state value)
  *   void ds3_request_set_storage_domain_id(const ds3_request* request, const char * const value)
- *   void ds3_request_set_type_ds3_tape_type(const ds3_request* request, const ds3_tape_type value)
+ *   void ds3_request_set_type(const ds3_request* request, const char * const value)
  *   void ds3_request_set_verify_pending_ds3_priority(const ds3_request* request, const ds3_priority value)
  *   void ds3_request_set_write_protected(const ds3_request* request, ds3_bool value)
  */

--- a/src/ds3_init_requests.c
+++ b/src/ds3_init_requests.c
@@ -153,40 +153,6 @@ static char* _get_ds3_tape_state_str(ds3_tape_state input) {
     }
 
 }
-static char* _get_ds3_tape_type_str(ds3_tape_type input) {
-    if (input == DS3_TAPE_TYPE_LTO5) {
-        return "LTO5";
-    } else if (input == DS3_TAPE_TYPE_LTO6) {
-        return "LTO6";
-    } else if (input == DS3_TAPE_TYPE_LTO7) {
-        return "LTO7";
-    } else if (input == DS3_TAPE_TYPE_LTO8) {
-        return "LTO8";
-    } else if (input == DS3_TAPE_TYPE_LTO_CLEANING_TAPE) {
-        return "LTO_CLEANING_TAPE";
-    } else if (input == DS3_TAPE_TYPE_TS_JC) {
-        return "TS_JC";
-    } else if (input == DS3_TAPE_TYPE_TS_JY) {
-        return "TS_JY";
-    } else if (input == DS3_TAPE_TYPE_TS_JK) {
-        return "TS_JK";
-    } else if (input == DS3_TAPE_TYPE_TS_JD) {
-        return "TS_JD";
-    } else if (input == DS3_TAPE_TYPE_TS_JZ) {
-        return "TS_JZ";
-    } else if (input == DS3_TAPE_TYPE_TS_JL) {
-        return "TS_JL";
-    } else if (input == DS3_TAPE_TYPE_TS_CLEANING_TAPE) {
-        return "TS_CLEANING_TAPE";
-    } else if (input == DS3_TAPE_TYPE_UNKNOWN) {
-        return "UNKNOWN";
-    } else if (input == DS3_TAPE_TYPE_FORBIDDEN) {
-        return "FORBIDDEN";
-    } else {
-        return "";
-    }
-
-}
 static char* _get_ds3_auto_inspect_mode_str(ds3_auto_inspect_mode input) {
     if (input == DS3_AUTO_INSPECT_MODE_NEVER) {
         return "NEVER";
@@ -1517,8 +1483,8 @@ void ds3_request_set_tape_state_ds3_tape_state(const ds3_request* request, const
     _set_query_param(request, "tape_state", (const char*)_get_ds3_tape_state_str(value));
 
 }
-void ds3_request_set_tape_type_ds3_tape_type(const ds3_request* request, const ds3_tape_type value) {
-    _set_query_param(request, "tape_type", (const char*)_get_ds3_tape_type_str(value));
+void ds3_request_set_tape_type(const ds3_request* request, const char * const value) {
+    _set_query_param(request, "tape_type", value);
 
 }
 void ds3_request_set_target_data_policy(const ds3_request* request, const char * const value) {
@@ -1577,8 +1543,8 @@ void ds3_request_set_type_ds3_tape_partition_failure_type(const ds3_request* req
     _set_query_param(request, "type", (const char*)_get_ds3_tape_partition_failure_type_str(value));
 
 }
-void ds3_request_set_type_ds3_tape_type(const ds3_request* request, const ds3_tape_type value) {
-    _set_query_param(request, "type", (const char*)_get_ds3_tape_type_str(value));
+void ds3_request_set_type(const ds3_request* request, const char * const value) {
+    _set_query_param(request, "type", value);
 
 }
 void ds3_request_set_type_ds3_target_failure_type(const ds3_request* request, const ds3_target_failure_type value) {
@@ -2946,7 +2912,7 @@ ds3_request* ds3_init_put_storage_domain_spectra_s3_request(const char* name) {
     }
     return (ds3_request*) request;
 }
-ds3_request* ds3_init_put_tape_storage_domain_member_spectra_s3_request(const char* storage_domain_id, const char* tape_partition_id, const ds3_tape_type tape_type) {
+ds3_request* ds3_init_put_tape_storage_domain_member_spectra_s3_request(const char* storage_domain_id, const char* tape_partition_id, const char* tape_type) {
     struct _ds3_request* request = _common_request_init(HTTP_POST, _build_path("/_rest_/storage_domain_member/", NULL, NULL));
     if (storage_domain_id != NULL) {
         _set_query_param((ds3_request*) request, "storage_domain_id", storage_domain_id);
@@ -2954,8 +2920,9 @@ ds3_request* ds3_init_put_tape_storage_domain_member_spectra_s3_request(const ch
     if (tape_partition_id != NULL) {
         _set_query_param((ds3_request*) request, "tape_partition_id", tape_partition_id);
     }
-    _set_query_param((ds3_request*) request, "tape_type", _get_ds3_tape_type_str(tape_type));
-
+    if (tape_type != NULL) {
+        _set_query_param((ds3_request*) request, "tape_type", tape_type);
+    }
     return (ds3_request*) request;
 }
 ds3_request* ds3_init_delete_storage_domain_failure_spectra_s3_request(const char *const resource_id) {
@@ -3088,15 +3055,16 @@ ds3_request* ds3_init_clean_tape_drive_spectra_s3_request(const char *const reso
 
     return (ds3_request*) request;
 }
-ds3_request* ds3_init_put_tape_density_directive_spectra_s3_request(const ds3_tape_drive_type density, const char* partition_id, const ds3_tape_type tape_type) {
+ds3_request* ds3_init_put_tape_density_directive_spectra_s3_request(const ds3_tape_drive_type density, const char* partition_id, const char* tape_type) {
     struct _ds3_request* request = _common_request_init(HTTP_POST, _build_path("/_rest_/tape_density_directive/", NULL, NULL));
     _set_query_param((ds3_request*) request, "density", _get_ds3_tape_drive_type_str(density));
 
     if (partition_id != NULL) {
         _set_query_param((ds3_request*) request, "partition_id", partition_id);
     }
-    _set_query_param((ds3_request*) request, "tape_type", _get_ds3_tape_type_str(tape_type));
-
+    if (tape_type != NULL) {
+        _set_query_param((ds3_request*) request, "tape_type", tape_type);
+    }
     return (ds3_request*) request;
 }
 ds3_request* ds3_init_delete_permanently_lost_tape_spectra_s3_request(const char *const resource_id) {


### PR DESCRIPTION
The enum `tape_type` is now generated as a string. This is a consequence of SA-217 which was merged to autogen in https://github.com/SpectraLogic/ds3_autogen/pull/452
