### PR TITLE
CSDK-268: 4.1 API

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,7 +8,8 @@ add_library(ds3 SHARED
             ds3_utils.h ds3_utils.c
             ds3_connection.h ds3_connection.c
             ds3_uint64_string_map.h ds3_uint64_string_map.c
-            ds3_response_header_utils.h ds3_response_header_utils.c)
+            ds3_response_header_utils.h ds3_response_header_utils.c
+            ds3_bool.h)
 
 if (WIN32)
     set(CMAKE_BUILD_TYPE Release)
@@ -85,6 +86,7 @@ else(WIN32)
                 "ds3_utils.h"
                 "ds3_uint64_string_map.h"
                 "ds3_response_header_utils.h"
+                "ds3_bool.h"
             DESTINATION
                 "/usr/local/include")
     install(TARGETS ds3 DESTINATION lib)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,7 +6,9 @@ add_library(ds3 SHARED
             ds3_string_multimap.h ds3_string_multimap.c
             ds3_string.h ds3_string.c
             ds3_utils.h ds3_utils.c
-            ds3_connection.h ds3_connection.c)
+            ds3_connection.h ds3_connection.c
+            ds3_uint64_string_map.h ds3_uint64_string_map.c
+            ds3_response_header_utils.h ds3_response_header_utils.c)
 
 if (WIN32)
     set(CMAKE_BUILD_TYPE Release)
@@ -81,6 +83,8 @@ else(WIN32)
                 "ds3_string_multimap.h"
                 "ds3_string_multimap_impl.h"
                 "ds3_utils.h"
+                "ds3_uint64_string_map.h"
+                "ds3_response_header_utils.h"
             DESTINATION
                 "/usr/local/include")
     install(TARGETS ds3 DESTINATION lib)

--- a/src/ds3.c
+++ b/src/ds3.c
@@ -28,6 +28,7 @@
 #include "ds3_connection.h"
 #include "ds3_request.h"
 #include "ds3_string_multimap_impl.h"
+#include "ds3_uint64_string_map.h"
 #include "ds3_utils.h"
 
 #ifdef _WIN32
@@ -400,6 +401,26 @@ ds3_bulk_object_list_response* ds3_init_bulk_object_list_with_size(size_t num_ob
 
     return obj_list;
 }
+
+//TODO begin added
+void ds3_head_object_response_free(ds3_head_object_response* response) {
+    if (response == NULL) {
+        return;
+    }
+    if (response->blob_checksum_type != NULL) {
+        g_free(response->blob_checksum_type);
+    }
+    if (response->metadata != NULL) {
+        ds3_metadata_free(response->metadata);
+    }
+    if (response->blob_checksums != NULL) {
+        ds3_uint64_string_map_free(response->blob_checksums);
+    }
+
+    g_free(response);
+}
+//TODO end added
+
 void ds3_multipart_upload_part_response_free(ds3_multipart_upload_part_response* response) {
     if (response == NULL) {
         return;

--- a/src/ds3.c
+++ b/src/ds3.c
@@ -401,26 +401,6 @@ ds3_bulk_object_list_response* ds3_init_bulk_object_list_with_size(size_t num_ob
 
     return obj_list;
 }
-
-//TODO begin added
-void ds3_head_object_response_free(ds3_head_object_response* response) {
-    if (response == NULL) {
-        return;
-    }
-    if (response->blob_checksum_type != NULL) {
-        g_free(response->blob_checksum_type);
-    }
-    if (response->metadata != NULL) {
-        ds3_metadata_free(response->metadata);
-    }
-    if (response->blob_checksums != NULL) {
-        ds3_uint64_string_map_free(response->blob_checksums);
-    }
-
-    g_free(response);
-}
-//TODO end added
-
 void ds3_multipart_upload_part_response_free(ds3_multipart_upload_part_response* response) {
     if (response == NULL) {
         return;
@@ -454,6 +434,23 @@ void ds3_delete_objects_response_free(ds3_delete_objects_response* response) {
         ds3_str_free(response->strings_list[index]);
     }
     g_free(response->strings_list);
+    g_free(response);
+}
+
+void ds3_head_object_response_free(ds3_head_object_response* response) {
+    if (response == NULL) {
+        return;
+    }
+    if (response->blob_checksum_type != NULL) {
+        g_free(response->blob_checksum_type);
+    }
+    if (response->metadata != NULL) {
+        ds3_metadata_free(response->metadata);
+    }
+    if (response->blob_checksums != NULL) {
+        ds3_uint64_string_map_free(response->blob_checksums);
+    }
+
     g_free(response);
 }
 

--- a/src/ds3.h
+++ b/src/ds3.h
@@ -26,6 +26,7 @@
 #include <stdint.h>
 #include <string.h>
 #include <curl/curl.h>
+#include "ds3_bool.h"
 #include "ds3_string.h"
 #include "ds3_string_multimap.h"
 #include "ds3_uint64_string_map.h"
@@ -69,10 +70,6 @@ typedef struct {
 }ds3_metadata_keys_result;
 
 typedef struct _ds3_metadata ds3_metadata;
-
-typedef enum {
-    False, True
-}ds3_bool;
 
 typedef enum {
     HTTP_GET,

--- a/src/ds3.h
+++ b/src/ds3.h
@@ -28,6 +28,7 @@
 #include <curl/curl.h>
 #include "ds3_string.h"
 #include "ds3_string_multimap.h"
+#include "ds3_uint64_string_map.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -627,6 +628,15 @@ typedef enum {
     DS3_CHECKSUM_TYPE_SHA_256,
     DS3_CHECKSUM_TYPE_SHA_512
 }ds3_checksum_type;
+
+//TODO manually added
+typedef struct {
+    ds3_metadata* metadata;
+    ds3_checksum_type *blob_checksum_type;
+    ds3_uint64_string_map* blob_checksums;
+}ds3_head_object_response;
+//TODO end manually added
+
 typedef struct {
     ds3_str* data_policy_id;
     ds3_str* id;
@@ -2146,6 +2156,9 @@ typedef struct _ds3_client {
     ds3_connection_pool* connection_pool;
 }ds3_client;
 
+// TODO begin added
+LIBRARY_API void ds3_head_object_response_free(ds3_head_object_response* response);
+// TODO end added
 LIBRARY_API void ds3_azure_data_replication_rule_response_free(ds3_azure_data_replication_rule_response* response_data);
 LIBRARY_API void ds3_blob_response_free(ds3_blob_response* response_data);
 LIBRARY_API void ds3_bucket_response_free(ds3_bucket_response* response_data);
@@ -2641,7 +2654,7 @@ LIBRARY_API ds3_request* ds3_init_head_bucket_request(const char *const bucket_n
 LIBRARY_API ds3_error* ds3_head_bucket_request(const ds3_client* client, const ds3_request* request);
 
 LIBRARY_API ds3_request* ds3_init_head_object_request(const char* bucket_name, const char *const object_name);
-LIBRARY_API ds3_error* ds3_head_object_request(const ds3_client* client, const ds3_request* request, ds3_metadata** _metadata);
+LIBRARY_API ds3_error* ds3_head_object_request(const ds3_client* client, const ds3_request* request, ds3_head_object_response** response);
 
 LIBRARY_API ds3_request* ds3_init_initiate_multi_part_upload_request(const char *const bucket_name, const char *const object_name);
 LIBRARY_API ds3_error* ds3_initiate_multi_part_upload_request(const ds3_client* client, const ds3_request* request, ds3_initiate_multipart_upload_result_response** response);

--- a/src/ds3.h
+++ b/src/ds3.h
@@ -629,13 +629,11 @@ typedef enum {
     DS3_CHECKSUM_TYPE_SHA_512
 }ds3_checksum_type;
 
-//TODO manually added
 typedef struct {
     ds3_metadata* metadata;
     ds3_checksum_type *blob_checksum_type;
     ds3_uint64_string_map* blob_checksums;
 }ds3_head_object_response;
-//TODO end manually added
 
 typedef struct {
     ds3_str* data_policy_id;
@@ -2156,9 +2154,6 @@ typedef struct _ds3_client {
     ds3_connection_pool* connection_pool;
 }ds3_client;
 
-// TODO begin added
-LIBRARY_API void ds3_head_object_response_free(ds3_head_object_response* response);
-// TODO end added
 LIBRARY_API void ds3_azure_data_replication_rule_response_free(ds3_azure_data_replication_rule_response* response_data);
 LIBRARY_API void ds3_blob_response_free(ds3_blob_response* response_data);
 LIBRARY_API void ds3_bucket_response_free(ds3_bucket_response* response_data);
@@ -2353,6 +2348,7 @@ LIBRARY_API void ds3_list_multi_part_uploads_result_response_free(ds3_list_multi
 
 LIBRARY_API void ds3_request_free(ds3_request* request);
 LIBRARY_API void ds3_error_free(ds3_error* error);
+LIBRARY_API void ds3_head_object_response_free(ds3_head_object_response* response);
 LIBRARY_API void ds3_multipart_upload_part_response_free(ds3_multipart_upload_part_response* response);
 LIBRARY_API void ds3_complete_multipart_upload_response_free(ds3_complete_multipart_upload_response* response);
 LIBRARY_API void ds3_delete_objects_response_free(ds3_delete_objects_response* response);

--- a/src/ds3_bool.h
+++ b/src/ds3_bool.h
@@ -1,0 +1,41 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2018 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+#ifndef __DS3_BOOL__
+#define __DS3_BOOL__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// For windows DLL symbol exports.
+#ifdef _WIN32
+#    ifdef LIBRARY_EXPORTS
+#        define LIBRARY_API __declspec(dllexport)
+#    else
+#        define LIBRARY_API __declspec(dllimport)
+#    endif
+#else
+#    define LIBRARY_API
+#endif
+
+typedef enum {
+    False, True
+}ds3_bool;
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/src/ds3_requests.c
+++ b/src/ds3_requests.c
@@ -43,6 +43,7 @@
 //The max size of an uint64_t is 20 characters + NULL
 #define STRING_BUFFER_SIZE 32
 
+
 struct _ds3_metadata {
     GHashTable* metadata;
 };
@@ -233,7 +234,6 @@ void ds3_metadata_keys_free(ds3_metadata_keys_result* metadata_keys) {
     }
     g_free(metadata_keys);
 }
-
 static bool attribute_equal(const struct _xmlAttr* attribute, const char* attribute_name) {
     return xmlStrcmp(attribute->name, (const xmlChar*) attribute_name) == 0;
 }
@@ -13537,7 +13537,6 @@ ds3_error* ds3_head_bucket_request(const ds3_client* client, const ds3_request* 
     return _internal_request_dispatcher(client, request, NULL, NULL, NULL, NULL, NULL);
 }
 
-// TODO begin modified
 ds3_error* ds3_head_object_request(const ds3_client* client, const ds3_request* request, ds3_head_object_response** response) {
     ds3_error* error;
     ds3_string_multimap* return_headers;
@@ -13563,7 +13562,6 @@ ds3_error* ds3_head_object_request(const ds3_client* client, const ds3_request* 
 
     return error;
 }
-// TODO end modified
 
 ds3_error* ds3_initiate_multi_part_upload_request(const ds3_client* client, const ds3_request* request, ds3_initiate_multipart_upload_result_response** response) {
     ds3_error* error;

--- a/src/ds3_response_header_utils.c
+++ b/src/ds3_response_header_utils.c
@@ -22,7 +22,7 @@
 
 // Converts a ds3_str* containing a checksum value into a ds3_checksum_type*.
 // If conversion is not possible, then NULL is returned.
-ds3_checksum_type* _convert_str_to_checksum_type(const ds3_log* log, const ds3_str* checksum_str) {
+static ds3_checksum_type* _convert_str_to_checksum_type(const ds3_log* log, const ds3_str* checksum_str) {
     if (checksum_str == NULL || checksum_str->value == NULL) {
         return NULL;
     }
@@ -76,7 +76,7 @@ ds3_checksum_type* get_blob_checksum_type(const ds3_log* log, ds3_string_multima
 }
 
 // Retrieves the offset value at the end of a blob checksum header
-uint64_t* _get_offset_from_key(const ds3_str* key) {
+static uint64_t* _get_offset_from_key(const ds3_str* key) {
     if (key == NULL) {
         return NULL;
     }

--- a/src/ds3_response_header_utils.c
+++ b/src/ds3_response_header_utils.c
@@ -1,0 +1,120 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2018 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+#include "ds3_response_header_utils.h"
+#include "ds3_string_multimap_impl.h"
+#include "ds3_utils.h"
+
+#define BLOB_CHECKSUM_HEADER "ds3-blob-checksum-offset-"
+#define BLOB_CHECKSUM_TYPE_HEADER "ds3-blob-checksum-type"
+
+// Converts a ds3_str* containing a checksum value into a ds3_checksum_type*.
+// If conversion is not possible, then NULL is returned.
+ds3_checksum_type* _convert_str_to_checksum_type(const ds3_log* log, const ds3_str* checksum_str) {
+    if (checksum_str == NULL || checksum_str->value == NULL) {
+        return NULL;
+    }
+    ds3_checksum_type* checksum_type = g_new0(ds3_checksum_type, 1);
+    if (strcmp(checksum_str->value, "CRC_32") == 0) {
+        *checksum_type = DS3_CHECKSUM_TYPE_CRC_32;
+        return checksum_type;
+    }
+    if (strcmp(checksum_str->value, "CRC_32C") == 0) {
+        *checksum_type = DS3_CHECKSUM_TYPE_CRC_32C;
+        return checksum_type;
+    }
+    if (strcmp(checksum_str->value, "MD5") == 0) {
+        *checksum_type = DS3_CHECKSUM_TYPE_MD5;
+        return checksum_type;
+    }
+    if (strcmp(checksum_str->value, "SHA_256") == 0) {
+        *checksum_type = DS3_CHECKSUM_TYPE_SHA_256;
+        return checksum_type;
+    }
+    if (strcmp(checksum_str->value, "SHA_512") == 0) {
+        *checksum_type = DS3_CHECKSUM_TYPE_SHA_512;
+        return checksum_type;
+    }
+    g_free(checksum_type);
+    ds3_log_message(log, DS3_ERROR, "ERROR: Unknown value of '%s' for ds3_checksum_type.", checksum_str->value);
+    return NULL;
+}
+
+// Retrieves the blob checksum type from the response headers.
+ds3_checksum_type* get_blob_checksum_type(const ds3_log* log, ds3_string_multimap* response_headers) {
+    ds3_checksum_type* checksum_type = NULL;
+
+    ds3_str* header_key = ds3_str_init(BLOB_CHECKSUM_TYPE_HEADER);
+    ds3_string_multimap_entry* entry = ds3_string_multimap_lookup(response_headers, header_key);
+    ds3_str_free(header_key);
+
+    if (entry == NULL) {
+        return NULL;
+    }
+
+    ds3_str* value = ds3_string_multimap_entry_get_value_by_index(entry, 0);
+    ds3_string_multimap_entry_free(entry);
+
+
+    checksum_type = _convert_str_to_checksum_type(log, value);
+    ds3_str_free(value);
+
+
+    return checksum_type;
+}
+
+// Retrieves the offset value at the end of a blob checksum header
+uint64_t* _get_offset_from_key(const ds3_str* key) {
+    if (key == NULL) {
+        return NULL;
+    }
+
+    uint64_t* offset = g_new0(uint64_t, 1);
+    *offset = strtoull(key->value+strlen(BLOB_CHECKSUM_HEADER), NULL, 10);
+    return offset;
+}
+
+// Retrieves the blob checksums from the response headers.
+ds3_uint64_string_map* get_blob_checksums(const ds3_log* log, ds3_string_multimap* response_headers) {
+    if (response_headers == NULL) {
+        ds3_log_message(log, DS3_WARN, "Cannot parse blob checksum headers: response headers was null\n");
+        return NULL;
+    }
+
+    ds3_uint64_string_map* blob_map = ds3_uint64_string_map_init();
+
+    GHashTableIter iter;
+    gpointer _key, _value;
+    ds3_str* key = NULL;
+
+    g_hash_table_iter_init(&iter, ds3_string_multimap_get_hashtable(response_headers));
+    while(g_hash_table_iter_next(&iter, &_key, &_value)) {
+        key = (ds3_str*) _key;
+        if (g_str_has_prefix(key->value, BLOB_CHECKSUM_HEADER)) {
+            ds3_string_multimap_entry* entry = ds3_string_multimap_lookup(response_headers, key);
+            if (entry != NULL && ds3_string_multimap_entry_get_num_values(entry) > 0) {
+                uint64_t* offset = _get_offset_from_key(key);
+                if (offset != NULL) {
+                    ds3_str* value = ds3_string_multimap_entry_get_value_by_index(entry, 0);
+                    ds3_uint64_string_map_insert(blob_map, offset, value);
+                    ds3_str_free(value);
+                }
+                g_free(offset);
+            }
+            ds3_string_multimap_entry_free(entry);
+        }
+    }
+    return blob_map;
+}

--- a/src/ds3_response_header_utils.h
+++ b/src/ds3_response_header_utils.h
@@ -1,0 +1,49 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2018 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+
+#ifndef __DS3_RESPONSE_HEADER_UTILS__
+#define __DS3_RESPONSE_HEADER_UTILS__
+
+#include <stdlib.h>
+#include <glib.h>
+
+#include "ds3_string.h"
+#include "stdint.h"
+#include "ds3_string_multimap.h"
+#include "ds3.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// For windows DLL symbol exports.
+#ifdef _WIN32
+#    ifdef LIBRARY_EXPORTS
+#        define LIBRARY_API __declspec(dllexport)
+#    else
+#        define LIBRARY_API __declspec(dllimport)
+#    endif
+#else
+#    define LIBRARY_API
+#endif
+
+LIBRARY_API ds3_checksum_type* get_blob_checksum_type(const ds3_log* log, ds3_string_multimap* response_headers);
+LIBRARY_API ds3_uint64_string_map* get_blob_checksums(const ds3_log* log, ds3_string_multimap* response_headers);
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/src/ds3_string.c
+++ b/src/ds3_string.c
@@ -55,4 +55,3 @@ void ds3_str_free(ds3_str* string) {
     }
     g_free(string);
 }
-

--- a/src/ds3_string_multimap.h
+++ b/src/ds3_string_multimap.h
@@ -37,7 +37,7 @@ typedef struct _ds3_string_multimap       ds3_string_multimap;
 typedef struct _ds3_string_multimap_entry ds3_string_multimap_entry;
 
 
-//opertions for manipulating a hash map as a ds3_str multi map
+//operations for manipulating a hash map as a ds3_str multi map
 LIBRARY_API ds3_string_multimap*       ds3_string_multimap_init(void);
 LIBRARY_API void                       ds3_string_multimap_insert(ds3_string_multimap* map, const ds3_str* key, const ds3_str* value);
 LIBRARY_API void                       ds3_string_multimap_insert_entry(ds3_string_multimap* map, const ds3_string_multimap_entry* entry);  // caller frees all passed in values
@@ -45,7 +45,7 @@ LIBRARY_API ds3_string_multimap_entry* ds3_string_multimap_lookup(ds3_string_mul
 LIBRARY_API void                       ds3_string_multimap_free(ds3_string_multimap* map);
 
 
-//opertions for manipulating a ds3_string_multi_map_entry
+//operations for manipulating a ds3_string_multi_map_entry
 LIBRARY_API ds3_string_multimap_entry* ds3_string_multimap_entry_init(const ds3_str* key);
 LIBRARY_API ds3_str*                   ds3_string_multimap_entry_get_key(const ds3_string_multimap_entry* entry);
 LIBRARY_API void                       ds3_string_multimap_entry_add_value(ds3_string_multimap_entry* entry, const ds3_str* value);

--- a/src/ds3_uint64_string_map.c
+++ b/src/ds3_uint64_string_map.c
@@ -13,7 +13,18 @@
  * ****************************************************************************
  */
 
+#include <glib.h>
+
 #include "ds3_uint64_string_map.h"
+
+struct _ds3_uint64_string_map {
+    GHashTable* hash; //key is uint64_t*, value is ds3_str*
+};
+
+// Used to iterate through a ds3_uint64_string_map
+struct _ds3_uint64_string_map_iter {
+    GHashTableIter* g_iter;
+};
 
 static void _internal_uint64_free(gpointer data) {
     g_free((uint64_t*) data);
@@ -31,21 +42,29 @@ ds3_uint64_string_map* ds3_uint64_string_map_init(void) {
 }
 
 // Inserts a safe copy of the key-value pair into the map. Returns true if the key did not exist yet.
-gboolean ds3_uint64_string_map_insert(ds3_uint64_string_map* map, const uint64_t* key, const ds3_str* value) {
+ds3_bool ds3_uint64_string_map_insert(ds3_uint64_string_map* map, const uint64_t* key, const ds3_str* value) {
     if (map == NULL || map->hash == NULL) {
         return FALSE;
     }
     ds3_str* value_cpy = ds3_str_dup(value);
     uint64_t* key_cpy = g_new0(uint64_t, 1);
     *key_cpy = *key;
-    return g_hash_table_insert(map->hash, key_cpy, value_cpy);
+    gboolean result = g_hash_table_insert(map->hash, key_cpy, value_cpy);
+    if (result == FALSE) {
+        return False;
+    }
+    return True;
 }
 
-gboolean ds3_uint64_string_map_contains(ds3_uint64_string_map* map, uint64_t* key) {
+ds3_bool ds3_uint64_string_map_contains(ds3_uint64_string_map* map, uint64_t* key) {
     if (map == NULL || map->hash == NULL) {
         return FALSE;
     }
-    return g_hash_table_contains(map->hash, key);
+    gboolean result = g_hash_table_contains(map->hash, key);
+    if (result == FALSE) {
+        return False;
+    }
+    return True;
 }
 
 // Looks up the value for the provided key and returns a duplicate of the ds3_str value if found.
@@ -60,8 +79,8 @@ ds3_str* ds3_uint64_string_map_lookup(ds3_uint64_string_map* map, uint64_t* key)
     return ds3_str_dup((ds3_str*)value);
 }
 
-guint ds3_uint64_string_map_size(ds3_uint64_string_map* map) {
-    return g_hash_table_size(map->hash);
+uint64_t ds3_uint64_string_map_size(ds3_uint64_string_map* map) {
+    return (uint64_t) g_hash_table_size(map->hash);
 }
 
 void ds3_uint64_string_map_free(ds3_uint64_string_map* map) {

--- a/src/ds3_uint64_string_map.c
+++ b/src/ds3_uint64_string_map.c
@@ -1,0 +1,119 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2018 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+#include "ds3_uint64_string_map.h"
+
+ds3_uint64_string_map* ds3_uint64_string_map_init(void) {
+    // Create a hash table with uint64_t* as the key, and ds3_str* as the value
+    struct _ds3_uint64_string_map* map = g_new0(struct _ds3_uint64_string_map, 1);
+    map->hash = g_hash_table_new_full(g_int64_hash, g_int64_equal, NULL, (void *)ds3_str_free);
+    return (ds3_uint64_string_map*) map;
+}
+
+// Returns true if the key did not exist yet
+gboolean ds3_uint64_string_map_insert(ds3_uint64_string_map* map, uint64_t* key, const ds3_str* value) {
+    if (map == NULL || map->hash == NULL) {
+        return FALSE;
+    }
+    ds3_str* value_cpy = ds3_str_dup(value);
+    return g_hash_table_insert(map->hash, key, value_cpy);
+}
+
+gboolean ds3_uint64_string_map_contains(ds3_uint64_string_map* map, uint64_t* key) {
+    if (map == NULL || map->hash == NULL) {
+        return FALSE;
+    }
+    return g_hash_table_contains(map->hash, key);
+}
+
+// Looks up the value for the provided key and returns a duplicate of the ds3_str value if found.
+ds3_str* ds3_uint64_string_map_lookup(ds3_uint64_string_map* map, uint64_t* key) {
+    if (map == NULL || map->hash == NULL) {
+        return NULL;
+    }
+    GPtrArray* value = g_hash_table_lookup(map->hash, key);
+    if (value == NULL) {
+        return NULL;
+    }
+    return ds3_str_dup((ds3_str*)value);
+}
+
+void ds3_uint64_string_map_free(ds3_uint64_string_map* map) {
+    if (map == NULL) {
+        return;
+    }
+    if (map->hash != NULL) {
+        // Release all elements in the hash
+        g_hash_table_remove_all(map->hash);
+
+        // Release the hash
+        g_hash_table_unref(map->hash);
+    }
+
+    // Release the map
+    g_free(map);
+}
+
+ds3_uint64_string_map_iter* ds3_uint64_string_map_iter_init(ds3_uint64_string_map* map) {
+    // Create iterator for ds3_uint64_string_map
+    struct _ds3_uint64_string_map_iter* iter = g_new0(struct _ds3_uint64_string_map_iter, 1);
+    iter->g_iter = g_new0(GHashTableIter, 1);
+    g_hash_table_iter_init(iter->g_iter, map->hash);
+    return (ds3_uint64_string_map_iter*) iter;
+}
+
+void ds3_uint64_string_map_iter_free(ds3_uint64_string_map_iter* iter) {
+    if (iter == NULL) {
+        return;
+    }
+    if (iter->g_iter != NULL) {
+        g_free(iter->g_iter);
+    }
+    // Release the iterator
+    g_free(iter);
+}
+
+// Returns the next pair of key-value in the map if exists. The pair must be deallocate
+// using ds3_uint64_string_pair_free. The returned pair is a copy of the values within
+// the map, so modification of the pair does not affect the map. If there is no next
+// entry then NULL is returned.
+ds3_uint64_string_pair* ds3_uint64_string_map_iter_next(ds3_uint64_string_map_iter* iter) {
+    gpointer g_key;
+    gpointer g_value;
+    gboolean has_next = g_hash_table_iter_next(iter->g_iter, &g_key, &g_value);
+    if (has_next == FALSE) {
+        return NULL;
+    }
+    // Allocate the pair ds3_uint64_string_pair
+    struct _ds3_uint64_string_pair* pair = g_new0(struct _ds3_uint64_string_pair, 1);
+
+    // Set key and value of the pair
+    uint64_t* key_ptr = (uint64_t*) g_key;
+    pair->key = *key_ptr;
+    pair->value = ds3_str_dup((ds3_str*)g_value);
+
+    return (ds3_uint64_string_pair*) pair;
+}
+
+void ds3_uint64_string_pair_free(ds3_uint64_string_pair* pair) {
+    if (pair == NULL) {
+        return;
+    }
+    if (pair->value != NULL) {
+        ds3_str_free(pair->value);
+    }
+    g_free(pair);
+}
+

--- a/src/ds3_uint64_string_map.h
+++ b/src/ds3_uint64_string_map.h
@@ -17,10 +17,10 @@
 #define __DS3_UINT64_T_STRING_MAP__
 
 #include <stdlib.h>
-#include <glib.h>
 
-#include "ds3_string.h"
 #include "stdint.h"
+#include "ds3_bool.h"
+#include "ds3_string.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -37,23 +37,14 @@ extern "C" {
 #    define LIBRARY_API
 #endif
 
-struct _ds3_uint64_string_map {
-    GHashTable* hash; //key is uint64_t*, value is ds3_str*
-};
-
 typedef struct _ds3_uint64_string_map ds3_uint64_string_map;
 
 LIBRARY_API ds3_uint64_string_map* ds3_uint64_string_map_init(void);
-LIBRARY_API gboolean ds3_uint64_string_map_insert(ds3_uint64_string_map* map, const uint64_t* key, const ds3_str* value);
-LIBRARY_API gboolean ds3_uint64_string_map_contains(ds3_uint64_string_map* map, uint64_t* key);
+LIBRARY_API ds3_bool ds3_uint64_string_map_insert(ds3_uint64_string_map* map, const uint64_t* key, const ds3_str* value);
+LIBRARY_API ds3_bool ds3_uint64_string_map_contains(ds3_uint64_string_map* map, uint64_t* key);
 LIBRARY_API ds3_str* ds3_uint64_string_map_lookup(ds3_uint64_string_map* map, uint64_t* key);
 LIBRARY_API void     ds3_uint64_string_map_free(ds3_uint64_string_map* map);
-LIBRARY_API guint    ds3_uint64_string_map_size(ds3_uint64_string_map* map);
-
-// Used to iterate through a ds3_uint64_string_map
-struct _ds3_uint64_string_map_iter {
-    GHashTableIter* g_iter;
-};
+LIBRARY_API uint64_t    ds3_uint64_string_map_size(ds3_uint64_string_map* map);
 
 typedef struct _ds3_uint64_string_map_iter ds3_uint64_string_map_iter;
 

--- a/src/ds3_uint64_string_map.h
+++ b/src/ds3_uint64_string_map.h
@@ -44,10 +44,11 @@ struct _ds3_uint64_string_map {
 typedef struct _ds3_uint64_string_map ds3_uint64_string_map;
 
 LIBRARY_API ds3_uint64_string_map* ds3_uint64_string_map_init(void);
-LIBRARY_API gboolean ds3_uint64_string_map_insert(ds3_uint64_string_map* map, uint64_t* key, const ds3_str* value);
+LIBRARY_API gboolean ds3_uint64_string_map_insert(ds3_uint64_string_map* map, const uint64_t* key, const ds3_str* value);
 LIBRARY_API gboolean ds3_uint64_string_map_contains(ds3_uint64_string_map* map, uint64_t* key);
 LIBRARY_API ds3_str* ds3_uint64_string_map_lookup(ds3_uint64_string_map* map, uint64_t* key);
 LIBRARY_API void     ds3_uint64_string_map_free(ds3_uint64_string_map* map);
+LIBRARY_API guint    ds3_uint64_string_map_size(ds3_uint64_string_map* map);
 
 // Used to iterate through a ds3_uint64_string_map
 struct _ds3_uint64_string_map_iter {

--- a/src/ds3_uint64_string_map.h
+++ b/src/ds3_uint64_string_map.h
@@ -1,0 +1,76 @@
+/*
+ * ******************************************************************************
+ *   Copyright 2014-2017 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+#ifndef __DS3_UINT64_T_STRING_MAP__
+#define __DS3_UINT64_T_STRING_MAP__
+
+#include <stdlib.h>
+#include <glib.h>
+
+#include "ds3_string.h"
+#include "stdint.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// For windows DLL symbol exports.
+#ifdef _WIN32
+#    ifdef LIBRARY_EXPORTS
+#        define LIBRARY_API __declspec(dllexport)
+#    else
+#        define LIBRARY_API __declspec(dllimport)
+#    endif
+#else
+#    define LIBRARY_API
+#endif
+
+struct _ds3_uint64_string_map {
+    GHashTable* hash; //key is uint64_t*, value is ds3_str*
+};
+
+typedef struct _ds3_uint64_string_map ds3_uint64_string_map;
+
+LIBRARY_API ds3_uint64_string_map* ds3_uint64_string_map_init(void);
+LIBRARY_API gboolean ds3_uint64_string_map_insert(ds3_uint64_string_map* map, uint64_t* key, const ds3_str* value);
+LIBRARY_API gboolean ds3_uint64_string_map_contains(ds3_uint64_string_map* map, uint64_t* key);
+LIBRARY_API ds3_str* ds3_uint64_string_map_lookup(ds3_uint64_string_map* map, uint64_t* key);
+LIBRARY_API void     ds3_uint64_string_map_free(ds3_uint64_string_map* map);
+
+// Used to iterate through a ds3_uint64_string_map
+struct _ds3_uint64_string_map_iter {
+    GHashTableIter* g_iter;
+};
+
+typedef struct _ds3_uint64_string_map_iter ds3_uint64_string_map_iter;
+
+// Used to encapsulate a safe key-value pair of the ds3_uint64_string_map during iteration.
+struct _ds3_uint64_string_pair {
+    uint64_t key;
+    ds3_str* value;
+};
+
+typedef struct _ds3_uint64_string_pair ds3_uint64_string_pair;
+
+LIBRARY_API void ds3_uint64_string_pair_free(ds3_uint64_string_pair* pair);
+
+LIBRARY_API ds3_uint64_string_map_iter* ds3_uint64_string_map_iter_init(ds3_uint64_string_map* map);
+LIBRARY_API ds3_uint64_string_pair* ds3_uint64_string_map_iter_next(ds3_uint64_string_map_iter* iter);
+LIBRARY_API void     ds3_uint64_string_map_iter_free(ds3_uint64_string_map_iter* iter);
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -78,6 +78,7 @@ add_executable(ds3_c_tests
   service_tests.cpp
   connection_tests.cpp
   put_directory.cpp
+  unit_tests.cpp
   test.cpp)
 
 add_test(regression_tests ds3_c_tests)

--- a/test/metadata_tests.cpp
+++ b/test/metadata_tests.cpp
@@ -25,7 +25,7 @@ BOOST_AUTO_TEST_CASE( put_metadata ) {
     ds3_bulk_object_list_response* obj_list;
     uint64_t metadata_count;
     ds3_master_object_list_response* bulk_response;
-    ds3_metadata* metadata_result;
+    ds3_head_object_response* head_object_response;
     ds3_metadata_entry* metadata_entry;
     const char* file_name[1] = {"resources/beowulf.txt"};
     ds3_client* client = get_client();
@@ -63,20 +63,21 @@ BOOST_AUTO_TEST_CASE( put_metadata ) {
 
     request = ds3_init_head_object_request(bucket_name, "resources/beowulf.txt");
 
-    error = ds3_head_object_request(client, request, &metadata_result);
+    error = ds3_head_object_request(client, request, &head_object_response);
     ds3_request_free(request);
     handle_error(error);
-    BOOST_CHECK(metadata_result != NULL);
+    BOOST_CHECK(head_object_response != NULL);
+    BOOST_CHECK(head_object_response->metadata != NULL);
 
-    metadata_count = ds3_metadata_size(metadata_result);
+    metadata_count = ds3_metadata_size(head_object_response->metadata);
     BOOST_CHECK(metadata_count == 1);
 
-    metadata_entry = ds3_metadata_get_entry(metadata_result, "name");
+    metadata_entry = ds3_metadata_get_entry(head_object_response->metadata, "name");
     BOOST_CHECK(metadata_entry != NULL);
     BOOST_CHECK(g_strcmp0(metadata_entry->name->value, "name") == 0);
 
     ds3_metadata_entry_free(metadata_entry);
-    ds3_metadata_free(metadata_result);
+    ds3_head_object_response_free(head_object_response);
     clear_bucket(client, bucket_name);
     free_client(client);
 }
@@ -87,7 +88,7 @@ BOOST_AUTO_TEST_CASE( put_emtpy_metadata ) {
     ds3_bulk_object_list_response* obj_list;
     uint64_t metadata_count;
     ds3_master_object_list_response* bulk_response;
-    ds3_metadata* metadata_result;
+    ds3_head_object_response* head_object_response;
     ds3_metadata_entry* metadata_entry;
     const char* file_name[1] = {"resources/beowulf.txt"};
     ds3_client* client = get_client();
@@ -125,18 +126,18 @@ BOOST_AUTO_TEST_CASE( put_emtpy_metadata ) {
 
     request = ds3_init_head_object_request(bucket_name, "resources/beowulf.txt");
 
-    error = ds3_head_object_request(client, request, &metadata_result);
+    error = ds3_head_object_request(client, request, &head_object_response);
     ds3_request_free(request);
     handle_error(error);
 
-    metadata_count = ds3_metadata_size(metadata_result);
+    metadata_count = ds3_metadata_size(head_object_response->metadata);
     BOOST_CHECK(metadata_count == 0);
 
-    metadata_entry = ds3_metadata_get_entry(metadata_result, "name");
+    metadata_entry = ds3_metadata_get_entry(head_object_response->metadata, "name");
     BOOST_CHECK(metadata_entry == NULL);
 
     ds3_metadata_entry_free(metadata_entry);
-    ds3_metadata_free(metadata_result);
+    ds3_head_object_response_free(head_object_response);
     clear_bucket(client, bucket_name);
     free_client(client);
 }
@@ -147,7 +148,7 @@ BOOST_AUTO_TEST_CASE( put_null_metadata ) {
     ds3_bulk_object_list_response* obj_list;
     uint64_t metadata_count;
     ds3_master_object_list_response* bulk_response;
-    ds3_metadata* metadata_result;
+    ds3_head_object_response* head_object_response;
     ds3_metadata_entry* metadata_entry;
     const char* file_name[1] = {"resources/beowulf.txt"};
     ds3_client* client = get_client();
@@ -185,18 +186,18 @@ BOOST_AUTO_TEST_CASE( put_null_metadata ) {
 
     request = ds3_init_head_object_request(bucket_name, "resources/beowulf.txt");
 
-    error = ds3_head_object_request(client, request, &metadata_result);
+    error = ds3_head_object_request(client, request, &head_object_response);
     ds3_request_free(request);
     handle_error(error);
 
-    metadata_count = ds3_metadata_size(metadata_result);
+    metadata_count = ds3_metadata_size(head_object_response->metadata);
     BOOST_CHECK(metadata_count == 0);
 
-    metadata_entry = ds3_metadata_get_entry(metadata_result, "name");
+    metadata_entry = ds3_metadata_get_entry(head_object_response->metadata, "name");
     BOOST_CHECK(metadata_entry == NULL);
 
     ds3_metadata_entry_free(metadata_entry);
-    ds3_metadata_free(metadata_result);
+    ds3_head_object_response_free(head_object_response);
     clear_bucket(client, bucket_name);
     free_client(client);
 }
@@ -221,7 +222,7 @@ BOOST_AUTO_TEST_CASE( head_bucket ) {
 BOOST_AUTO_TEST_CASE( head_folder ) {
     printf("-----Testing head_folder-------\n");
 
-    ds3_metadata* metadata_result;
+    ds3_head_object_response* head_object_response;
     ds3_client* client = get_client();
     const char* bucket_name = "head_folder_test";
 
@@ -236,11 +237,11 @@ BOOST_AUTO_TEST_CASE( head_folder ) {
 
     request = ds3_init_head_object_request(bucket_name, test_folder);
 
-    error = ds3_head_object_request(client, request, &metadata_result);
+    error = ds3_head_object_request(client, request, &head_object_response);
     ds3_request_free(request);
     handle_error(error);
-    BOOST_CHECK(metadata_result != NULL);
-    ds3_metadata_free(metadata_result);
+    BOOST_CHECK(head_object_response->metadata != NULL);
+    ds3_head_object_response_free(head_object_response);
 
     clear_bucket(client, bucket_name);
     free_client(client);
@@ -252,7 +253,7 @@ BOOST_AUTO_TEST_CASE( put_multiple_metadata_items ) {
     ds3_bulk_object_list_response* obj_list;
     uint64_t metadata_count;
     ds3_master_object_list_response* bulk_response;
-    ds3_metadata* metadata_result;
+    ds3_head_object_response* head_object_response;
     ds3_metadata_entry* metadata_entry;
     const char* file_name[1] = {"resources/beowulf.txt"};
     //ds3_client* client = get_client_at_loglvl(DS3_DEBUG);
@@ -284,27 +285,27 @@ BOOST_AUTO_TEST_CASE( put_multiple_metadata_items ) {
     ds3_master_object_list_response_free(bulk_response);
 
     request = ds3_init_head_object_request(bucket_name, "resources/beowulf.txt");
-    error = ds3_head_object_request(client, request, &metadata_result);
+    error = ds3_head_object_request(client, request, &head_object_response);
     ds3_request_free(request);
     handle_error(error);
-    BOOST_CHECK(metadata_result != NULL);
+    BOOST_CHECK(head_object_response->metadata != NULL);
 
-    metadata_count = ds3_metadata_size(metadata_result);
+    metadata_count = ds3_metadata_size(head_object_response->metadata);
     BOOST_CHECK(metadata_count == 2);
 
-    metadata_entry = ds3_metadata_get_entry(metadata_result, "name");
+    metadata_entry = ds3_metadata_get_entry(head_object_response->metadata, "name");
     BOOST_CHECK(metadata_entry != NULL);
     BOOST_CHECK(g_strcmp0(metadata_entry->name->value, "name") == 0);
     BOOST_CHECK(g_strcmp0(metadata_entry->values[0]->value, "value") == 0);
     ds3_metadata_entry_free(metadata_entry);
 
-    metadata_entry = ds3_metadata_get_entry(metadata_result, "key");
+    metadata_entry = ds3_metadata_get_entry(head_object_response->metadata, "key");
     BOOST_CHECK(metadata_entry != NULL);
     BOOST_CHECK(g_strcmp0(metadata_entry->name->value, "key") == 0);
     BOOST_CHECK(g_strcmp0(metadata_entry->values[0]->value, "value2") == 0);
 
     ds3_metadata_entry_free(metadata_entry);
-    ds3_metadata_free(metadata_result);
+    ds3_head_object_response_free(head_object_response);
     clear_bucket(client, bucket_name);
     free_client(client);
 }
@@ -325,7 +326,7 @@ BOOST_AUTO_TEST_CASE( metadata_keys ) {
     ds3_bulk_object_list_response* obj_list;
     uint64_t metadata_count;
     ds3_master_object_list_response* bulk_response;
-    ds3_metadata* metadata_result = NULL;
+    ds3_head_object_response* head_object_response;
     ds3_metadata_keys_result* metadata_keys = NULL;
 
     const char* file_name[1] = {"resources/beowulf.txt"};
@@ -360,15 +361,15 @@ BOOST_AUTO_TEST_CASE( metadata_keys ) {
 
     request = ds3_init_head_object_request(bucket_name, "resources/beowulf.txt");
 
-    error = ds3_head_object_request(client, request, &metadata_result);
+    error = ds3_head_object_request(client, request, &head_object_response);
     ds3_request_free(request);
     handle_error(error);
-    BOOST_CHECK(metadata_result != NULL);
+    BOOST_CHECK(head_object_response->metadata != NULL);
 
-    metadata_count = ds3_metadata_size(metadata_result);
+    metadata_count = ds3_metadata_size(head_object_response->metadata);
     BOOST_CHECK(metadata_count == 2);
 
-    metadata_keys = ds3_metadata_keys(metadata_result);
+    metadata_keys = ds3_metadata_keys(head_object_response->metadata);
     BOOST_CHECK(metadata_keys != NULL);
 
     BOOST_CHECK(metadata_keys->num_keys == 2);
@@ -376,7 +377,7 @@ BOOST_AUTO_TEST_CASE( metadata_keys ) {
     BOOST_CHECK(contains_key(metadata_keys, "name"));
 
     ds3_metadata_keys_free(metadata_keys);
-    ds3_metadata_free(metadata_result);
+    ds3_head_object_response_free(head_object_response);
     clear_bucket(client, bucket_name);
     free_client(client);
 }

--- a/test/negative_tests.cpp
+++ b/test/negative_tests.cpp
@@ -132,11 +132,11 @@ BOOST_AUTO_TEST_CASE(head_object_with_empty_object_name){
     handle_error(error);
 
     ds3_request* request = ds3_init_head_object_request(bucket_name, "");
-    ds3_metadata* response = NULL;
+    ds3_head_object_response* response = NULL;
     error = ds3_head_object_request(client, request, &response);
     ds3_request_free(request);
     clear_bucket(client, bucket_name);
-    ds3_metadata_free(response);
+    ds3_head_object_response_free(response);
     free_client(client);
 
     BOOST_REQUIRE(error != NULL);
@@ -155,11 +155,11 @@ BOOST_AUTO_TEST_CASE(head_object_with_null_object_name){
     handle_error(error);
 
     ds3_request* request = ds3_init_head_object_request(bucket_name, NULL);
-    ds3_metadata* response = NULL;
+    ds3_head_object_response* response = NULL;
     error = ds3_head_object_request(client, request, &response);
     ds3_request_free(request);
     clear_bucket(client, bucket_name);
-    ds3_metadata_free(response);
+    ds3_head_object_response_free(response);
     free_client(client);
 
     BOOST_REQUIRE(error != NULL);

--- a/test/unit_tests.cpp
+++ b/test/unit_tests.cpp
@@ -1,0 +1,65 @@
+/*   Copyright 2014-2018 Spectra Logic Corporation. All Rights Reserved.
+ *   Licensed under the Apache License, Version 2.0 (the "License"). You may not use
+ *   this file except in compliance with the License. A copy of the License is located at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file.
+ *   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ *   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *   specific language governing permissions and limitations under the License.
+ * ****************************************************************************
+ */
+
+#include <stdio.h>
+#include "ds3.h"
+#include "test.h"
+#include <boost/test/unit_test.hpp>
+
+#include "../src/ds3_uint64_string_map.h"
+
+BOOST_AUTO_TEST_CASE( ds3_unit64_string_map ) {
+    const char* const_value = "my value";
+    uint64_t key = 10;
+
+    // Create map
+    ds3_uint64_string_map* map = ds3_uint64_string_map_init();
+
+    // Verify map does not have content
+    gboolean contains = ds3_uint64_string_map_contains(map, &key);
+    BOOST_CHECK(contains == FALSE);
+
+    // Insert stuff into map
+    ds3_str* value = ds3_str_init(const_value);
+    ds3_uint64_string_map_insert(map, &key, value);
+    ds3_str_free(value);
+
+    // Verify map has content
+    contains = ds3_uint64_string_map_contains(map, &key);
+    BOOST_CHECK(contains == TRUE);
+
+    // Iterate through map
+    ds3_uint64_string_map_iter* iter = ds3_uint64_string_map_iter_init(map);
+    ds3_uint64_string_pair* pair = NULL;
+    while((pair = ds3_uint64_string_map_iter_next(iter)) != NULL) {
+        BOOST_CHECK(pair != NULL);
+        BOOST_CHECK(pair->value != NULL);
+        if (pair->value != NULL) {
+            BOOST_CHECK(strcmp(const_value, ds3_str_value(pair->value)) == 0);
+        }
+        BOOST_CHECK_EQUAL(pair->key, key);
+
+        ds3_uint64_string_pair_free(pair);
+    }
+
+    ds3_uint64_string_map_iter_free(iter);
+
+    // Get stuff from map
+    value = ds3_uint64_string_map_lookup(map, &key);
+    BOOST_CHECK(value != NULL);
+    BOOST_CHECK(strcmp(const_value, ds3_str_value(value)) == 0);
+    ds3_str_free(value);
+
+    // Free map
+    ds3_uint64_string_map_free(map);
+}


### PR DESCRIPTION
**Changes**
- Created `ds3_uint64_string_map` for mapping offsets to checksums in Head Object header parsing.
- Created `ds3_response_header_utils` which contains utils for: 
  - parsing headers with key `ds3-blob-checksum-offset-X` into a blob checksum map of blob offset to blob checksum.
  - parsing `ds3-blob-checksum-type` header for determining blob checksum type.
- Created new `ds3_head_object_response` which contains the new blob checksum map and metadata.
` Created free function for `ds3_head_object_response`.

**Tests**
- Added unit tests for new map and header parsing functions.
- Updated old tests to use new response struct.